### PR TITLE
Update Bento.MetainfoError.transform to adapt to malformed torrent

### DIFF
--- a/lib/bento/metainfo.ex
+++ b/lib/bento/metainfo.ex
@@ -49,6 +49,6 @@ defmodule Bento.Metainfo do
   end
 
   defp transform(info_dict) do
-    info_dict |> Map.to_list() |> Enum.map(fn {k, v} -> {String.to_existing_atom(k), v} end)
+    info_dict |> Map.to_list() |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
   end
 end

--- a/lib/bento/metainfo.ex
+++ b/lib/bento/metainfo.ex
@@ -49,6 +49,9 @@ defmodule Bento.Metainfo do
   end
 
   defp transform(info_dict) do
-    info_dict |> Map.to_list() |> Enum.map(fn {k, v} -> {String.to_atom(k), v} end)
+    fields = [:"piece length", :pieces, :private, :name, :files, :length, :md5sum]
+    fields |> Enum.map(fn field ->
+      {field, Map.get(info_dict, Atom.to_string(field))}
+    end)
   end
 end


### PR DESCRIPTION
Hey @ericls, mind dropping a comment explaining the two changes you made? Happy to merge your changes into Bento, but was curious about the `to_existing_atom` -> `to_atom` change especially since you already define the atoms in the function, and the motivation behind the change in the first place. If there's a bug I missed, I'd love to hear about it!
