### PR TITLE
Implement `Bento.Decoder.transform/2`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,25 +1,21 @@
-# Bento
+# Bento [![ci](https://img.shields.io/github/actions/workflow/status/folz/bento/build-test.yml?label=CI&logo=github&style=flat-square)](https://github.com/folz/bento/actions/workflows/build-test.yml？style=flat-square) [![hex.pm](https://img.shields.io/hexpm/v/bento.svg?label=Hex&style=flat-square)](https://hex.pm/packages/bento)
 
-[![Build and Test](https://github.com/folz/bento/actions/workflows/build-test.yml/badge.svg)](https://github.com/folz/bento/actions/workflows/build-test.yml)
-[![hex.pm](https://img.shields.io/hexpm/v/bento.svg)](https://hex.pm/packages/bento)
-[![hexdocs.pm](https://img.shields.io/badge/hex-docs-4B275F)](https://hexdocs.pm/bento/api-reference.html)
+Bento is a new [Bencoding](https://en.wikipedia.org/wiki/Bencode) library for Elixir focusing on incredibly fast **speed** without sacrificing **simplicity**, **completeness**, or **correctness**.
 
-Bento is a new [Bencoding](https://en.wikipedia.org/wiki/Bencode) library for Elixir focusing on incredibly fast **speed**
-without sacrificing **simplicity**, **completeness**, or **correctness**.
+It takes inspiration from [Poison](https://github.com/devinus/poison), a pure-Elixir JSON library, and uses several techniques found there to achieve this speed:
 
-It takes inspiration from [Poison](https://github.com/devinus/poison), a
-pure-Elixir JSON library, and uses several techniques found there to achieve this speed:
-
-- Extensive [sub-binary matching](http://erlang.org/euc/07/papers/1700Gustafsson.pdf)
-- A hand-rolled **parser** using several techniques [known to benefit HiPE](http://erlang.org/workshop/2003/paper/p36-sagonas.pdf)
-  for native compilation
-- [IO list](http://jlouisramblings.blogspot.com/2013/07/problematic-traits-in-erlang.html)
-  encoding
-- **Single-pass** decoding
+- Extensive [sub-binary matching](http://erlang.org/euc/07/papers/1700Gustafsson.pdf).
+- A hand-rolled **parser** using several techniques [known to benefit HiPE](http://erlang.org/workshop/2003/paper/p36-sagonas.pdf) for native compilation.
+- [IO list](http://jlouisramblings.blogspot.com/2013/07/problematic-traits-in-erlang.html) encoding.
+- **Single-pass** decoding.
 
 Additionally, and unlike some other Elixir bencoding libraries, Bento will also reject all malformed input. This guarantees you're working with a well-formed bencoded file.
 
 Preliminary [benchmarking](#benchmarking) shows that Bento performs over 2x faster when encoding, and at least as fast when decoding, compared to other existing Elixir libraries.
+
+## Documentation
+
+Documentation is [available on Hexdocs](https://hexdocs.pm/bento).
 
 ## Installation
 
@@ -57,7 +53,7 @@ iex> Bento.decode!("d3:fool3:bar3:baze3:qux4:norfe")
 %{"foo" => ["bar", "baz"], "qux" => "norf"}
 ```
 
-Bento is also metainfo-aware and comes with a .torrent decoder out of the box:
+Bento is also metainfo-aware and comes with a `*.torrent` decoder out of the box:
 
 ```elixir
 iex> File.read!("test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent") |> Bento.torrent!()
@@ -85,7 +81,7 @@ iex> File.read!("test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent") |> Bento.
 }
 ```
 
-Since Bento uses [Poison](https://hex.pm/packages/poison)'s Decoder module for `.torrent()`, this means it also supports decoding bencoded data into any struct you choose, like so:
+In addition to parsing torrents via `Bento.torrent!/1`, It's also available decoding any bencoded data into any struct you choose, like so:
 
 ```elixir
 defmodule Name do
@@ -110,4 +106,4 @@ PRs that add libraries to the benchmarks are greatly appreciated!
 
 ## License
 
-See [LICENSE](LICENSE).
+See [LICENSE](./LICENSE).

--- a/lib/bento.ex
+++ b/lib/bento.ex
@@ -47,9 +47,8 @@ defmodule Bento do
       iex> Bento.encode_to_iodata([1, "two", [3]])
       {:ok, [108, [[105, "1", 101], ["3", 58, "two"], [108, [[105, "3", 101]], 101]], 101]}
   """
-
   @spec encode_to_iodata(Encoder.bencodable(), Keyword.t()) :: success | failure
-        when success: {:ok, Encoder.t()},
+        when success: {:ok, iodata()},
              failure: {:error, Encoder.encode_err()}
   def encode_to_iodata(value, options \\ []) do
     encode(value, [iodata: true] ++ options)
@@ -61,8 +60,7 @@ defmodule Bento do
       iex> Bento.encode_to_iodata!([1, "two", [3]])
       [108, [[105, "1", 101], ["3", 58, "two"], [108, [[105, "3", 101]], 101]], 101]
   """
-
-  @spec encode_to_iodata!(Encoder.bencodable(), Keyword.t()) :: Encoder.t() | no_return()
+  @spec encode_to_iodata!(Encoder.bencodable(), Keyword.t()) :: iodata() | no_return()
   def encode_to_iodata!(value, options \\ []) do
     encode!(value, [iodata: true] ++ options)
   end
@@ -72,8 +70,17 @@ defmodule Bento do
 
       iex> Bento.decode("li1e3:twoli3eee")
       {:ok, [1, "two", [3]]}
+
+  Use `:as` as option to transform the parsed value into a struct.
+
+      defmodule User do
+        defstruct name: "John", age: 27
+      end
+
+      Bento.decode("d4:name3:Bobe", as: %User{})
+      # {:ok, %User{name: "Bob", age: 27}}
   """
-  @spec decode(iodata(), Keyword.t()) :: {:ok, Decoder.t()} | {:error, Decoder.decode_err()}
+  @spec decode(iodata(), Decoder.opts()) :: {:ok, Decoder.t()} | {:error, Decoder.decode_err()}
   def decode(iodata, options \\ []), do: Decoder.decode(iodata, options)
 
   @doc """
@@ -81,8 +88,17 @@ defmodule Bento do
 
       iex> Bento.decode!("li1e3:twoli3eee")
       [1, "two", [3]]
+
+  Use `:as` as option to transform the parsed value into a struct.
+
+      defmodule User do
+        defstruct name: "John", age: 27
+      end
+
+      Bento.decode!("d4:name3:Bobe", as: %User{})
+      # %User{name: "Bob", age: 27}
   """
-  @spec decode!(iodata(), Keyword.t()) :: Decoder.t() | no_return()
+  @spec decode!(iodata(), Decoder.opts()) :: Decoder.t() | no_return()
   def decode!(iodata, options \\ []), do: Decoder.decode!(iodata, options)
 
   @doc """

--- a/lib/bento.ex
+++ b/lib/bento.ex
@@ -5,7 +5,7 @@ defmodule Bento do
   This module contains high-level methods to encode and decode Bencoded data.
   """
 
-  alias Bento.{Encoder, Parser, Metainfo}
+  alias Bento.{Encoder, Decoder, Metainfo}
 
   @doc """
   Bencode a value.
@@ -73,11 +73,8 @@ defmodule Bento do
       iex> Bento.decode("li1e3:twoli3eee")
       {:ok, [1, "two", [3]]}
   """
-  @spec decode(iodata(), Keyword.t()) :: {:ok, Parser.t()} | {:error, Parser.parse_err()}
-  def decode(iodata, options \\ []) do
-    with {:ok, parsed} <- Parser.parse(iodata),
-         do: {:ok, Poison.Decode.decode(parsed, options)}
-  end
+  @spec decode(iodata(), Keyword.t()) :: {:ok, Decoder.t()} | {:error, Decoder.decode_err()}
+  def decode(iodata, options \\ []), do: Decoder.decode(iodata, options)
 
   @doc """
   Decode bencoded data to a value, raising an exception on error.
@@ -85,18 +82,14 @@ defmodule Bento do
       iex> Bento.decode!("li1e3:twoli3eee")
       [1, "two", [3]]
   """
-  @spec decode!(iodata(), Keyword.t()) :: Parser.t() | no_return()
-  def decode!(iodata, options \\ []) do
-    iodata
-    |> Parser.parse!()
-    |> Poison.Decode.decode(options)
-  end
+  @spec decode!(iodata(), Keyword.t()) :: Decoder.t() | no_return()
+  def decode!(iodata, options \\ []), do: Decoder.decode!(iodata, options)
 
   @doc """
   Like `decode`, but ensures the data is a valid torrent metainfo file.
   """
   @spec torrent(iodata()) :: {:ok, Metainfo.Torrent.t()} | failure
-        when failure: {:error, Parser.parse_err() | String.t()}
+        when failure: {:error, Decoder.decode_err() | String.t()}
   def torrent(iodata) do
     with {:ok, decoded} <- decode(iodata, as: %Metainfo.Torrent{}),
          {:ok, info} <- Metainfo.info(decoded),

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -4,32 +4,43 @@ defmodule Bento.Decoder do
   alias Bento.Parser
 
   @type t :: Parser.t() | struct()
+  @type opts :: [as: map() | list() | struct()]
 
-  @spec decode(iodata(), Keyword.t()) :: t() | {:error, Parser.parse_err()}
+  @spec decode(iodata(), opts()) :: t() | {:error, Parser.parse_err()}
   def decode(value, opts \\ []) do
     with {:ok, p} <- Parser.parse(value), do: {:ok, transform(p, opts)}
   end
 
-  @spec decode!(iodata(), Keyword.t()) :: t() | no_return()
+  @spec decode!(iodata(), opts()) :: t() | no_return()
   def decode!(value, opts \\ []) do
     Parser.parse!(value) |> transform(opts)
   end
 
-  defguardp is_transable(v, as) when is_map(v) and is_struct(as)
+  defguardp is_transable(v) when is_map(v) or is_list(v)
 
-  @spec transform(Parser.t(), Keyword.t()) :: t()
-  def transform(value, as: as) when is_transable(value, as) do
-    Enum.reduce(Map.from_struct(as), %{}, fn {key, default}, acc ->
-      item = Map.get(value, Atom.to_string(key), default)
-
-      if is_struct(default) do
-        Map.put(acc, key, transform(item, as: default))
-      else
-        Map.put(acc, key, item)
-      end
-    end)
-    |> Map.put(:__struct__, as.__struct__)
+  @spec transform(Parser.t(), opts()) :: t()
+  def transform(value, as: as) when is_transable(value) do
+    do_transform(value, as)
   end
 
   def transform(value, _opts), do: value
+
+  defp do_transform(value, as) when is_struct(as) do
+    do_transform(value, Map.from_struct(as))
+    |> Map.put(:__struct__, as.__struct__)
+  end
+
+  defp do_transform(value, as) when is_list(as) do
+    Enum.map(value, &transform(&1, as: List.first(as)))
+  end
+
+  defp do_transform(value, as) when is_map(as) do
+    Enum.reduce(as, %{}, fn {key, default}, acc ->
+      item = Map.get(value, to_string(key), default)
+
+      Map.put(acc, key, transform(item, as: default))
+    end)
+  end
+
+  defp do_transform(value, _as), do: value
 end

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -5,8 +5,9 @@ defmodule Bento.Decoder do
 
   @type t :: Parser.t() | struct()
   @type opts :: [as: map() | list() | struct()]
+  @type decode_err :: Parser.parse_err()
 
-  @spec decode(iodata(), opts()) :: t() | {:error, Parser.parse_err()}
+  @spec decode(iodata(), opts()) :: {:ok, t()} | {:error, decode_err()}
   def decode(value, opts \\ []) do
     with {:ok, p} <- Parser.parse(value), do: {:ok, transform(p, opts)}
   end

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -1,5 +1,7 @@
 defmodule Bento.Decoder do
-  @moduledoc false
+  @moduledoc """
+  Useful wrapper for `Bento.Parser`.
+  """
 
   alias Bento.Parser
 
@@ -7,11 +9,17 @@ defmodule Bento.Decoder do
   @type opts :: [as: map() | list() | struct()]
   @type decode_err :: Parser.parse_err()
 
+  @doc """
+  Decode a bencoded value.
+  """
   @spec decode(iodata(), opts()) :: {:ok, t()} | {:error, decode_err()}
   def decode(value, opts \\ []) do
     with {:ok, p} <- Parser.parse(value), do: {:ok, transform(p, opts)}
   end
 
+  @doc """
+  Decode a bencoded value, but raise an error if it fails.
+  """
   @spec decode!(iodata(), opts()) :: t() | no_return()
   def decode!(value, opts \\ []) do
     Parser.parse!(value) |> transform(opts)
@@ -19,6 +27,16 @@ defmodule Bento.Decoder do
 
   defguardp is_transable(v) when is_map(v) or is_list(v)
 
+  @doc """
+  Transform a parsed value into a struct.
+
+      defmodule User do
+        defstruct name: "John", age: 27
+      end
+
+      Bento.Decoder.transform(%{"name" => "Bob"}, as: %User{})
+      # %User{name: "Bob", age: 27}
+  """
   @spec transform(Parser.t(), opts()) :: t()
   def transform(value, as: as) when is_transable(value) do
     do_transform(value, as)

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -22,7 +22,7 @@ defmodule Bento.Decoder do
   """
   @spec decode!(iodata(), opts()) :: t() | no_return()
   def decode!(value, opts \\ []) do
-    Parser.parse!(value) |> transform(opts)
+    value |> Parser.parse!() |> transform(opts)
   end
 
   @doc """
@@ -48,7 +48,8 @@ defmodule Bento.Decoder do
 
   # Transwform for maps and structs
   defp transform_map(value, as) when is_struct(as) do
-    transform_map(value, Map.from_struct(as))
+    value
+    |> transform_map(Map.from_struct(as))
     |> Map.put(:__struct__, as.__struct__)
   end
 

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -25,8 +25,6 @@ defmodule Bento.Decoder do
     Parser.parse!(value) |> transform(opts)
   end
 
-  # defguardp is_transable(value) when is_map(value) or is_list(value)
-
   @doc """
   Transform a parsed value into a struct.
 

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -1,0 +1,35 @@
+defmodule Bento.Decoder do
+  @moduledoc false
+
+  alias Bento.Parser
+
+  @type t :: Parser.t() | struct()
+
+  @spec decode(iodata(), Keyword.t()) :: t() | {:error, Parser.parse_err()}
+  def decode(value, opts \\ []) do
+    with {:ok, p} <- Parser.parse(value), do: {:ok, transform(p, opts)}
+  end
+
+  @spec decode!(iodata(), Keyword.t()) :: t() | no_return()
+  def decode!(value, opts \\ []) do
+    Parser.parse!(value) |> transform(opts)
+  end
+
+  defguardp is_transable(v, as) when is_map(v) and is_struct(as)
+
+  @spec transform(Parser.t(), Keyword.t()) :: t()
+  def transform(value, as: as) when is_transable(value, as) do
+    Enum.reduce(Map.from_struct(as), %{}, fn {key, default}, acc ->
+      item = Map.get(value, Atom.to_string(key), default)
+
+      if is_struct(default) do
+        Map.put(acc, key, transform(item, as: default))
+      else
+        Map.put(acc, key, item)
+      end
+    end)
+    |> Map.put(:__struct__, as.__struct__)
+  end
+
+  def transform(value, _opts), do: value
+end

--- a/lib/bento/decoder.ex
+++ b/lib/bento/decoder.ex
@@ -63,11 +63,9 @@ defmodule Bento.Decoder do
   defp transform_map(value, _as), do: value
 
   # Transform for lists
-  defp transform_list([x | xs], [y | ys]) do
-    [transform(x, as: y) | transform_list(xs, ys)]
+  defp transform_list(value, [to]) do
+    Enum.map(value, &transform(&1, as: to))
   end
 
-  defp transform_list([], as), do: as
-  defp transform_list(_value, []), do: []
   defp transform_list(value, _as), do: value
 end

--- a/mix.exs
+++ b/mix.exs
@@ -63,7 +63,7 @@ defmodule Bento.Mixfile do
       extras: ["README.md", "LICENSE"],
       groups_for_modules: [
         # Bento,
-        Codec: [Bento.Encoder, Bento.Parser],
+        Codec: [Bento.Encoder, Bento.Decoder, Bento.Parser],
         Metainfo: [
           Bento.Metainfo,
           Bento.Metainfo.Torrent,

--- a/mix.exs
+++ b/mix.exs
@@ -45,7 +45,6 @@ defmodule Bento.Mixfile do
       {:dialyxir, "~> 1.2", only: :dev, runtime: false},
       {:ex_doc, "~> 0.27", only: :dev, runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
-      {:poison, "~> 3.1"},
       {:benchfella, "~> 0.3", only: :bench},
       {:bencode, github: "gausby/bencode", only: :bench},
       {:bencodex, github: "patrickgombert/Bencodex", only: :bench},

--- a/mix.lock
+++ b/mix.lock
@@ -1,13 +1,11 @@
 %{
   "benchfella": {:hex, :benchfella, "0.3.5", "b2122c234117b3f91ed7b43b6e915e19e1ab216971154acd0a80ce0e9b8c05f5", [:mix], [], "hexpm", "23f27cbc482cbac03fc8926441eb60a5e111759c17642bac005c3225f5eb809d"},
   "bencode": {:git, "https://github.com/gausby/bencode.git", "e9bd497f22ef5f4c481378ca1efbfde4a453b472", []},
-  "bencoded": {:git, "https://github.com/galina/bencoded.git", "c91333a3f7c9dd53baaf679cb5bc4204800c53f6", []},
   "bencoder": {:git, "https://github.com/alehander42/bencoder.git", "6457030dcb040510fbcbc0849cb7afb5a8a4a171", []},
   "bencodex": {:git, "https://github.com/patrickgombert/Bencodex.git", "b66a015e1402c5e4e19a759e73389d03bea7fdb6", []},
   "bunt": {:hex, :bunt, "0.2.1", "e2d4792f7bc0ced7583ab54922808919518d0e57ee162901a16a1b6664ef3b14", [:mix], [], "hexpm", "a330bfb4245239787b15005e66ae6845c9cd524a288f0d141c148b02603777a5"},
   "credo": {:hex, :credo, "1.6.7", "323f5734350fd23a456f2688b9430e7d517afb313fbd38671b8a4449798a7854", [:mix], [{:bunt, "~> 0.2.1", [hex: :bunt, repo: "hexpm", optional: false]}, {:file_system, "~> 0.2.8", [hex: :file_system, repo: "hexpm", optional: false]}, {:jason, "~> 1.0", [hex: :jason, repo: "hexpm", optional: false]}], "hexpm", "41e110bfb007f7eda7f897c10bf019ceab9a0b269ce79f015d54b0dcf4fc7dd3"},
   "dialyxir": {:hex, :dialyxir, "1.2.0", "58344b3e87c2e7095304c81a9ae65cb68b613e28340690dfe1a5597fd08dec37", [:mix], [{:erlex, ">= 0.2.6", [hex: :erlex, repo: "hexpm", optional: false]}], "hexpm", "61072136427a851674cab81762be4dbeae7679f85b1272b6d25c3a839aff8463"},
-  "earmark": {:hex, :earmark, "1.2.2", "f718159d6b65068e8daeef709ccddae5f7fdc770707d82e7d126f584cd925b74", [:mix], [], "hexpm", "59514c4a207f9f25c5252e09974367718554b6a0f41fe39f7dc232168f9cb309"},
   "earmark_parser": {:hex, :earmark_parser, "1.4.30", "0b938aa5b9bafd455056440cdaa2a79197ca5e693830b4a982beada840513c5f", [:mix], [], "hexpm", "3b5385c2d36b0473d0b206927b841343d25adb14f95f0110062506b300cd5a1b"},
   "eqc_ex": {:hex, :eqc_ex, "1.3.2", "a2a01442057db92de202cca9bd81e6581b50401af741c1b0cefc99d91d73fcfc", [:mix], [], "hexpm", "34a45401a9d554baee6bf50577b8dadcdfbc454f5f80845b7296966e905a20ad"},
   "erlex": {:hex, :erlex, "0.2.6", "c7987d15e899c7a2f34f5420d2a2ea0d659682c06ac607572df55a43753aa12e", [:mix], [], "hexpm", "2ed2e25711feb44d52b17d2780eabf998452f6efda104877a3881c2f8c0c0c75"},
@@ -18,5 +16,4 @@
   "makeup_elixir": {:hex, :makeup_elixir, "0.16.0", "f8c570a0d33f8039513fbccaf7108c5d750f47d8defd44088371191b76492b0b", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}, {:nimble_parsec, "~> 1.2.3", [hex: :nimble_parsec, repo: "hexpm", optional: false]}], "hexpm", "28b2cbdc13960a46ae9a8858c4bebdec3c9a6d7b4b9e7f4ed1502f8159f338e7"},
   "makeup_erlang": {:hex, :makeup_erlang, "0.1.1", "3fcb7f09eb9d98dc4d208f49cc955a34218fc41ff6b84df7c75b3e6e533cc65f", [:mix], [{:makeup, "~> 1.0", [hex: :makeup, repo: "hexpm", optional: false]}], "hexpm", "174d0809e98a4ef0b3309256cbf97101c6ec01c4ab0b23e926a9e17df2077cbb"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
-  "poison": {:hex, :poison, "3.1.0", "d9eb636610e096f86f25d9a46f35a9facac35609a7591b3be3326e99a0484665", [:mix], [], "hexpm", "fec8660eb7733ee4117b85f55799fd3833eb769a6df71ccf8903e8dc5447cfce"},
 }

--- a/test/bento/decoder_test.exs
+++ b/test/bento/decoder_test.exs
@@ -85,5 +85,12 @@ defmodule Bento.DecoderTest do
       assert Decoder.transform([], as: [%User{}]) == [%User{}]
       assert Decoder.transform(simple, as: [%UserMap{}]) == [%UserMap{}]
     end
+
+    test "transform a map into a map" do
+      simple = %{"user" => %{"name" => "Bob"}}
+      result = %{"user" => %User{age: 27, name: "Bob"}}
+
+      assert Decoder.transform(simple, as: %{"user" => %User{}}) == result
+    end
   end
 end

--- a/test/bento/decoder_test.exs
+++ b/test/bento/decoder_test.exs
@@ -64,5 +64,26 @@ defmodule Bento.DecoderTest do
 
       assert Decoder.transform(simple, as: %UserStruct{}) == result
     end
+
+    test "transform a list into a list" do
+      simple = [
+        %{"name" => "Bob"},
+        %{"list" => [%{"name" => "Alice"}]}
+      ]
+
+      result = [
+        %User{age: 27, name: "Bob"},
+        %UserList{list: [%User{age: 27, name: "Alice"}]}
+      ]
+
+      other = %{other: "value"}
+
+      assert Decoder.transform(simple, as: [%User{}, %UserList{}]) == result
+      assert Decoder.transform(simple, as: [%User{}, %UserList{}, other]) == result ++ [other]
+      assert Decoder.transform(simple, as: [%User{}]) == [%User{age: 27, name: "Bob"}]
+      assert Decoder.transform(simple, as: []) == []
+      assert Decoder.transform([], as: [%User{}]) == [%User{}]
+      assert Decoder.transform(simple, as: [%UserMap{}]) == [%UserMap{}]
+    end
   end
 end

--- a/test/bento/decoder_test.exs
+++ b/test/bento/decoder_test.exs
@@ -66,23 +66,10 @@ defmodule Bento.DecoderTest do
     end
 
     test "transform a list into a list" do
-      simple = [
-        %{"name" => "Bob"},
-        %{"list" => [%{"name" => "Alice"}]}
-      ]
+      simple = [%{"list" => [%{"name" => "Alice"}]}]
+      result = [%UserList{list: [%User{age: 27, name: "Alice"}]}]
 
-      result = [
-        %User{age: 27, name: "Bob"},
-        %UserList{list: [%User{age: 27, name: "Alice"}]}
-      ]
-
-      other = %{other: "value"}
-
-      assert Decoder.transform(simple, as: [%User{}, %UserList{}]) == result
-      assert Decoder.transform(simple, as: [%User{}, %UserList{}, other]) == result ++ [other]
-      assert Decoder.transform(simple, as: [%User{}]) == [%User{age: 27, name: "Bob"}]
-      assert Decoder.transform(simple, as: []) == []
-      assert Decoder.transform([], as: [%User{}]) == [%User{}]
+      assert Decoder.transform(simple, as: [%UserList{}]) == result
       assert Decoder.transform(simple, as: [%UserMap{}]) == [%UserMap{}]
     end
 

--- a/test/bento/decoder_test.exs
+++ b/test/bento/decoder_test.exs
@@ -1,0 +1,68 @@
+defmodule Bento.DecoderTest do
+  use ExUnit.Case, async: true
+
+  alias Bento.Decoder
+
+  test "decode" do
+    assert Decoder.decode("d4:spaml1:a1:bee") == {:ok, %{"spam" => ["a", "b"]}}
+  end
+
+  test "decode!" do
+    assert Decoder.decode!("d4:spaml1:a1:bee") == %{"spam" => ["a", "b"]}
+  end
+
+  describe "Transform" do
+    defmodule User do
+      defstruct name: "John", age: 27
+    end
+
+    test "transform a map into a struct" do
+      assert Decoder.transform(%{"name" => "Bob"}, as: %User{}) == %User{age: 27, name: "Bob"}
+    end
+
+    defmodule UserList do
+      defstruct list: [%User{}]
+    end
+
+    test "transform a map with list into a struct" do
+      simple = %{"list" => [%{"name" => "Bob"}]}
+      result = %UserList{list: [%User{age: 27, name: "Bob"}]}
+
+      assert Decoder.transform(simple, as: %UserList{}) == result
+    end
+
+    defmodule UserMap do
+      defstruct map: %{"user" => %User{}}
+    end
+
+    test "transform a map with map into a struct" do
+      simple = %{"map" => %{"user" => %{"name" => "Bob"}}}
+      result = %UserMap{map: %{"user" => %User{age: 27, name: "Bob"}}}
+
+      assert Decoder.transform(simple, as: %UserMap{}) == result
+    end
+
+    defmodule UserStruct do
+      defstruct struct: %UserMap{
+                  map: %{"user" => %UserList{list: [%User{}]}}
+                },
+                other: "value",
+                foo: "foo"
+    end
+
+    test "transform a map with struct into a struct" do
+      simple = %{
+        "struct" => %{"map" => %{"user" => %{"list" => [%{"name" => "Bob"}]}}},
+        "foo" => "bar"
+      }
+
+      result = %UserStruct{
+        struct: %UserMap{map: %{"user" => %UserList{list: [%User{age: 27, name: "Bob"}]}}},
+        other: "value",
+        foo: "bar"
+      }
+
+      assert Decoder.transform(simple, as: %UserStruct{}) == result
+    end
+  end
+end


### PR DESCRIPTION
Replace the old `Posison.Decode.decode/2` with `Bento.Decoder.transform/2`.

As you can see, the benchmark shows that there is no obvious difference in performance.

Earlier times:

```txt
## ParserBench
benchmark name      iterations   average time 
single (Bencodex)       500000   4.02 µs/op
single (Bento)          500000   6.36 µs/op
single (bencode)        100000   16.51 µs/op
multi (Bencodex)          5000   666.52 µs/op
multi (Bento)             1000   1110.96 µs/op
single (bencoder)         1000   1276.72 µs/op
multi (bencode)           1000   1941.72 µs/op
multi (bencoder)           500   7130.18 µs/op
```

Nowadays:

```txt
## ParserBench
benchmark name      iterations   average time 
single (Bencodex)       500000   4.24 µs/op
single (Bento)          500000   6.36 µs/op
single (bencode)        100000   14.28 µs/op
multi (Bencodex)          2000   603.69 µs/op
multi (Bento)             1000   1148.87 µs/op
single (bencoder)         1000   1511.96 µs/op
multi (bencode)           1000   1732.82 µs/op
multi (bencoder)           500   6760.21 µs/op
```

At this stage, I need to write some additional unit tests and documents to check if I have missed anything.

Moreover, I encapsulated `Bento.Parser` by the way.
