### PR TITLE
Include `:ex_doc` for MIX_ENV `:prod`

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,7 +18,9 @@ jobs:
         with:
           otp-version: 25
           elixir-version: 1.14
-      - run: mix do deps.get + deps.compile
+      - run: |
+          mix deps.get --only ${MIX_ENV}
+          mix deps.compile --force
       - run: mix compile --warnings-as-errors
       - run: mix docs
       - run: mix hex.publish --yes

--- a/mix.exs
+++ b/mix.exs
@@ -43,7 +43,7 @@ defmodule Bento.Mixfile do
   defp deps do
     [
       {:dialyxir, "~> 1.2", only: :dev, runtime: false},
-      {:ex_doc, "~> 0.27", only: :dev, runtime: false},
+      {:ex_doc, "~> 0.27", only: [:dev, :prod], runtime: false},
       {:credo, "~> 1.6", only: [:dev, :test], runtime: false},
       {:benchfella, "~> 0.3", only: :bench},
       {:bencode, github: "gausby/bencode", only: :bench},


### PR DESCRIPTION
Since `:ex_doc` is not in the environment`:prod`, when published:

```shell
$ MIX_ENV=prod mix doc
** (Mix) The task "docs" could not be found. Did you mean "do"?
```

This PR add `:ex_doc` into the environment`:prod` to solve this problem.
