### PR TITLE
Enforce BEP-3 dictionary key ordering and uniqueness requirements

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,12 +53,6 @@ iex> Bento.decode!("d3:fool3:bar3:baze3:qux4:norfe")
 %{"foo" => ["bar", "baz"], "qux" => "norf"}
 ```
 
-Bento strictly enforces the BEP-3 requirement that dictionary keys be
-unique and sorted in ascending order (compared as raw strings). Input
-with out-of-order or duplicate dictionary keys is rejected as invalid
-rather than decoded leniently, so a decoded value always re-encodes to
-the exact bytes it was parsed from.
-
 Bento is also metainfo-aware and comes with a `*.torrent` decoder out of the box:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -53,6 +53,12 @@ iex> Bento.decode!("d3:fool3:bar3:baze3:qux4:norfe")
 %{"foo" => ["bar", "baz"], "qux" => "norf"}
 ```
 
+Bento strictly enforces the BEP-3 requirement that dictionary keys be
+unique and sorted in ascending order (compared as raw strings). Input
+with out-of-order or duplicate dictionary keys is rejected as invalid
+rather than decoded leniently, so a decoded value always re-encodes to
+the exact bytes it was parsed from.
+
 Bento is also metainfo-aware and comes with a `*.torrent` decoder out of the box:
 
 ```elixir

--- a/lib/bento/parser.ex
+++ b/lib/bento/parser.ex
@@ -23,10 +23,6 @@ defmodule Bento.Parser do
   @moduledoc """
   A BEP-3 conforming Bencoding parser.
 
-  As required by BEP-3, dictionary keys must be unique and appear in
-  ascending order, compared as raw strings. Input with out-of-order or
-  duplicate keys is rejected as invalid.
-
   See:
 
   - http://www.bittorrent.org/beps/bep_0003.html#bencoding

--- a/lib/bento/parser.ex
+++ b/lib/bento/parser.ex
@@ -23,6 +23,10 @@ defmodule Bento.Parser do
   @moduledoc """
   A BEP-3 conforming Bencoding parser.
 
+  As required by BEP-3, dictionary keys must be unique and appear in
+  ascending order, compared as raw strings. Input with out-of-order or
+  duplicate keys is rejected as invalid.
+
   See:
 
   - http://www.bittorrent.org/beps/bep_0003.html#bencoding
@@ -145,6 +149,7 @@ defmodule Bento.Parser do
 
   defp map_pairs(str, acc) do
     {name, rest} = string_start(str)
+    validate_key_order(acc, name)
     {value, rest} = parse_value(rest)
 
     acc = [{name, value} | acc]
@@ -155,6 +160,17 @@ defmodule Bento.Parser do
       rest -> map_pairs(rest, acc)
     end
   end
+
+  # BEP-3 requires map keys to be unique and sorted as raw strings
+  defp validate_key_order([{name, _} | _], name) do
+    syntax_error("duplicate map key #{inspect(name)}")
+  end
+
+  defp validate_key_order([{prev, _} | _], name) when prev > name do
+    syntax_error("map key #{inspect(name)} out of order after #{inspect(prev)}")
+  end
+
+  defp validate_key_order(_acc, _name), do: :ok
 
   ## Errors
 

--- a/test/bento/parser_test.exs
+++ b/test/bento/parser_test.exs
@@ -72,11 +72,19 @@ defmodule Bento.ParserTest do
     assert_raise SyntaxError, fn -> parse!("d4:fooi4ee") end
     assert_raise SyntaxError, fn -> parse!("d4:foode") end
 
+    # BEP-3: keys must be unique and sorted as raw strings
+    assert_raise SyntaxError, fn -> parse!("d1:b0:1:a0:e") end
+    assert_raise SyntaxError, fn -> parse!("d1:a1:x1:a1:ye") end
+    assert_raise SyntaxError, fn -> parse!("d1:a0:1:B0:e") end
+    assert_raise SyntaxError, fn -> parse!("d3:food1:b0:1:a0:ee") end
+
     assert parse!("de") == %{}
     assert parse!("d3:foodee") == %{"foo" => %{}}
     assert parse!("d11:aaaaaaaaaaai4ee") == %{"aaaaaaaaaaa" => 4}
     assert parse!("d3:food3:bar3:bazee") == %{"foo" => %{"bar" => "baz"}}
     assert parse!("d3:food3:bardeee") == %{"foo" => %{"bar" => %{}}}
+    assert parse!("d1:a1:b3:foo3:bar1:x1:ye") == %{"a" => "b", "foo" => "bar", "x" => "y"}
+    assert parse!("d1:B0:1:a0:e") == %{"B" => "", "a" => ""}
   end
 
   test "collections" do


### PR DESCRIPTION
This PR adds strict validation to the Bencoding parser to enforce BEP-3 compliance regarding dictionary key ordering and uniqueness.

## Summary
The parser now validates that dictionary keys are unique and appear in ascending lexicographic order (as raw strings), rejecting any input that violates these requirements. This ensures that decoded values can be reliably re-encoded to produce identical bytes.

## Changes Made
- **Parser validation**: Added `validate_key_order/2` function that checks each dictionary key against the previously parsed key, rejecting:
  - Duplicate keys with a "duplicate map key" error
  - Out-of-order keys with an "out of order" error
- **Documentation**: Updated module docstring to document the BEP-3 key ordering requirement
- **README**: Added explanation of strict key validation behavior and its benefits for round-trip encoding/decoding
- **Tests**: Added comprehensive test cases covering:
  - Out-of-order keys (e.g., `d1:b0:1:a0:e`)
  - Duplicate keys (e.g., `d1:a1:x1:a1:ye`)
  - Case-sensitive ordering (e.g., `d1:a0:1:B0:e`)
  - Nested dictionary validation
  - Valid sorted key examples

## Implementation Details
The validation is performed during dictionary parsing in `map_pairs/2` by checking the current key against the most recently parsed key (which is at the head of the accumulator list). This approach leverages the fact that keys are accumulated in reverse order, so the previous key is always available for comparison.

https://claude.ai/code/session_018cRL7NfRKHv2vtrBDG7GVE