### PR TITLE
Support nonstandard UTF-8 keys in torrent metainfo files

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,8 @@ iex> File.read!("./test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent") |> Bent
       251, 153, 170, 31, 127, 175, 166, 9, 254, 133, 8, 42, 229, 43, 139, 86,
       ...>>,
     private: 0,
-    name: "ubuntu-14.04.4-desktop-amd64.iso"
+    name: "ubuntu-14.04.4-desktop-amd64.iso",
+    "name.utf-8": nil
   },
   announce: "http://torrent.ubuntu.com:6969/announce",
   "announce-list": [

--- a/lib/bento/metainfo.ex
+++ b/lib/bento/metainfo.ex
@@ -7,11 +7,21 @@ defmodule Bento.Metainfo do
   A batteries-included metainfo decoder.
 
   You probably want to use `Bento.torrent/1` instead of this module directly.
+
+  Keys are not restricted by the spec, so metainfo files may contain
+  nonstandard keys. Unrecognized keys are ignored when decoding into the
+  structs below, with the exception of the `"name.utf-8"` and
+  `"path.utf-8"` keys written by some clients, which are decoded into the
+  fields of the same name.
   """
 
   defmodule SingleFile do
     @moduledoc """
     A struct representing a single-file torrent metainfo file.
+
+    The nonstandard `"name.utf-8"` key written by some clients (e.g.
+    Vuze/Azureus) is decoded when present, holding the UTF-8 encoded
+    `name` of torrents whose standard fields use a legacy charset.
     """
 
     defstruct length: nil,
@@ -19,13 +29,15 @@ defmodule Bento.Metainfo do
               "piece length": nil,
               pieces: nil,
               private: 0,
-              name: nil
+              name: nil,
+              "name.utf-8": nil
 
     @type t :: %__MODULE__{
             "piece length": integer(),
             pieces: String.t(),
             private: integer(),
             name: String.t(),
+            "name.utf-8": String.t(),
             length: integer(),
             md5sum: String.t()
           }
@@ -34,22 +46,29 @@ defmodule Bento.Metainfo do
   defmodule MultiFile do
     @moduledoc """
     A struct representing a multi-file torrent metainfo file.
+
+    The nonstandard `"name.utf-8"` and `"path.utf-8"` keys written by
+    some clients (e.g. Vuze/Azureus) are decoded when present, holding
+    the UTF-8 encoded `name` and file `path`s of torrents whose
+    standard fields use a legacy charset.
     """
 
-    defstruct files: [%{path: [], length: nil}],
+    defstruct files: [%{path: [], length: nil, "path.utf-8": nil}],
               "piece length": nil,
               pieces: nil,
               private: 0,
-              name: nil
+              name: nil,
+              "name.utf-8": nil
 
     @type t :: %__MODULE__{
             files: [
-              %{path: [String.t()], length: integer()}
+              %{path: [String.t()], length: integer(), "path.utf-8": [String.t()]}
             ],
             "piece length": integer(),
             pieces: String.t(),
             private: integer(),
-            name: String.t()
+            name: String.t(),
+            "name.utf-8": String.t()
           }
   end
 

--- a/lib/bento/metainfo.ex
+++ b/lib/bento/metainfo.ex
@@ -8,20 +8,12 @@ defmodule Bento.Metainfo do
 
   You probably want to use `Bento.torrent/1` instead of this module directly.
 
-  Keys are not restricted by the spec, so metainfo files may contain
-  nonstandard keys. Unrecognized keys are ignored when decoding into the
-  structs below, with the exception of the `"name.utf-8"` and
-  `"path.utf-8"` keys written by some clients, which are decoded into the
-  fields of the same name.
+  Unknown keys are ignored, except nonstandard "name.utf-8" and "path.utf-8", which are decoded.
   """
 
   defmodule SingleFile do
     @moduledoc """
     A struct representing a single-file torrent metainfo file.
-
-    The nonstandard `"name.utf-8"` key written by some clients (e.g.
-    Vuze/Azureus) is decoded when present, holding the UTF-8 encoded
-    `name` of torrents whose standard fields use a legacy charset.
     """
 
     defstruct length: nil,
@@ -46,11 +38,6 @@ defmodule Bento.Metainfo do
   defmodule MultiFile do
     @moduledoc """
     A struct representing a multi-file torrent metainfo file.
-
-    The nonstandard `"name.utf-8"` and `"path.utf-8"` keys written by
-    some clients (e.g. Vuze/Azureus) are decoded when present, holding
-    the UTF-8 encoded `name` and file `path`s of torrents whose
-    standard fields use a legacy charset.
     """
 
     defstruct files: [%{path: [], length: nil, "path.utf-8": nil}],

--- a/test/bento/metainfo_test.exs
+++ b/test/bento/metainfo_test.exs
@@ -32,4 +32,73 @@ defmodule Bento.MetainfoTest do
     assert List.first(torrent.info.files).path == ["AdventuresOfHuckleberryFinn_librivox.m4b"]
     assert List.first(torrent.info.files).length == 309_931_842
   end
+
+  # Some clients (e.g. Vuze/Azureus) write nonstandard "name.utf-8" and
+  # "path.utf-8" keys, holding the UTF-8 encoding of torrents whose standard
+  # fields use a legacy charset. See https://github.com/folz/bento/issues/14
+  test "torrent file (single) with .utf-8 keys is decoded" do
+    data =
+      Bento.encode!(%{
+        "announce" => "http://tracker.example.com/announce",
+        "info" => %{
+          "length" => 42,
+          # "café.txt" in Latin-1, not valid UTF-8
+          "name" => <<"caf", 0xE9, ".txt">>,
+          "name.utf-8" => "café.txt",
+          "piece length" => 16_384,
+          "pieces" => <<0::160>>
+        }
+      })
+
+    torrent = Bento.torrent!(data)
+    assert torrent.info.name == <<"caf", 0xE9, ".txt">>
+    assert torrent.info."name.utf-8" == "café.txt"
+  end
+
+  test "torrent file (multi) with .utf-8 keys is decoded" do
+    data =
+      Bento.encode!(%{
+        "announce" => "http://tracker.example.com/announce",
+        "info" => %{
+          "files" => [
+            %{
+              "length" => 12,
+              "path" => ["dir", <<"caf", 0xE9, ".txt">>],
+              "path.utf-8" => ["dir", "café.txt"]
+            }
+          ],
+          "name" => <<"f", 0xF6, "lder">>,
+          "name.utf-8" => "földer",
+          "piece length" => 16_384,
+          "pieces" => <<0::160>>
+        }
+      })
+
+    torrent = Bento.torrent!(data)
+    assert torrent.info."name.utf-8" == "földer"
+
+    file = List.first(torrent.info.files)
+    assert file.path == ["dir", <<"caf", 0xE9, ".txt">>]
+    assert file."path.utf-8" == ["dir", "café.txt"]
+  end
+
+  test "unknown metainfo keys are allowed and ignored" do
+    data =
+      Bento.encode!(%{
+        "announce" => "http://tracker.example.com/announce",
+        "publisher" => "nobody",
+        "info" => %{
+          "length" => 42,
+          "name" => "file.txt",
+          "name.weird" => "file.txt",
+          "piece length" => 16_384,
+          "pieces" => <<0::160>>
+        }
+      })
+
+    torrent = Bento.torrent!(data)
+    assert torrent.info.name == "file.txt"
+    refute Map.has_key?(torrent, :publisher)
+    refute Map.has_key?(torrent.info, :"name.weird")
+  end
 end

--- a/test/bento/metainfo_test.exs
+++ b/test/bento/metainfo_test.exs
@@ -33,9 +33,7 @@ defmodule Bento.MetainfoTest do
     assert List.first(torrent.info.files).length == 309_931_842
   end
 
-  # Some clients (e.g. Vuze/Azureus) write nonstandard "name.utf-8" and
-  # "path.utf-8" keys, holding the UTF-8 encoding of torrents whose standard
-  # fields use a legacy charset. See https://github.com/folz/bento/issues/14
+  # Some clients write nonstandard "name.utf-8"/"path.utf-8" keys; see issue #14.
   test "torrent file (single) with .utf-8 keys is decoded" do
     data =
       Bento.encode!(%{


### PR DESCRIPTION
Fixes #14

- Decode nonstandard `"name.utf-8"` and `"path.utf-8"` keys (written by Vuze/Azureus, BitComet, etc.) into fields on `SingleFile` and `MultiFile`, matching libtorrent/Transmission/anacrolix/parse-torrent behavior
- Other unknown keys remain ignored; `torrent/1` shape validation unchanged; new fields default to `nil`
- The crash in #14 no longer reproduces on master (fixed by the #24/#25 transform rewrite); this restores the silently-dropped data
- Tests: single-file and multi-file torrents with `.utf-8` keys, plus unknown-keys tolerance
- Benchmarks (`Bento.torrent!/1`, Elixir 1.14/OTP 25, prod, best-of-5 × 2): single-file 5.7/6.1 → 5.6/5.7 µs/op; multi-file (321 files) 1049/850 → 941/987 µs/op — within noise; `mix bench` only covers the untouched parser
- CI: `ubuntu-latest` jobs green; `ubuntu-20.04` legs never schedule (GitHub retired those runners — pre-existing on all runs)

https://claude.ai/code/session_01BsQoJKLGSnM4Qh1UpAc19H