### PR TITLE
Add Bento.Magnet: BitTorrent magnet URI codec

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,103 @@
+# Agent instructions for Bento
+
+Bento is a pure-Elixir library (no NIFs, no runtime deps). Everything an
+agent needs is the BEAM toolchain plus four dev/test Hex packages from
+`mix.lock` (`stream_data` for tests; `credo`, `dialyxir`, `ex_doc` and
+their transitive deps for lint/typecheck/docs).
+
+## Toolchain setup (sandboxed/cloud environments)
+
+The project requires Elixir `~> 1.17` (see `mix.exs`); CI exercises
+Elixir 1.17–1.20 on OTP 27–29 (see
+`.github/workflows/build-test.yml`). In an environment with no BEAM
+toolchain, this recipe works and takes a couple of minutes:
+
+1. **Erlang via apt** (Ubuntu's Elixir is too old, but its Erlang is fine):
+
+   ```shell
+   sudo apt-get install -y elixir erlang-dev erlang-parsetools erlang-dialyzer
+   ```
+
+   `erlang-dev`/`erlang-parsetools` are required to compile `ex_doc`'s
+   deps (leex headers); `erlang-dialyzer` for `mix dialyzer`. This also
+   installs an Elixir that is too old - ignore it.
+
+2. **Elixir from precompiled GitHub release**, matched to the installed
+   OTP major (check with `erl -noshell -eval
+   'io:format(erlang:system_info(otp_release)), halt().'`):
+
+   ```shell
+   curl -fsSL -o /tmp/elixir.zip \
+     https://github.com/elixir-lang/elixir/releases/download/v1.17.3/elixir-otp-25.zip
+   sudo mkdir -p /opt/elixir && sudo unzip -q -o /tmp/elixir.zip -d /opt/elixir
+   ```
+
+3. **Environment** (every shell; the harness does not persist exports):
+
+   ```shell
+   export PATH=/opt/elixir/bin:$PATH LC_ALL=C.UTF-8 ELIXIR_ERL_OPTIONS="+fnu"
+   ```
+
+   Without the locale settings the VM runs in latin1 filename mode and
+   Elixir warns/misbehaves.
+
+## Hex and deps behind a TLS-intercepting proxy
+
+Cloud sandboxes often route egress through a proxy with a custom CA
+(curl trusts it via `SSL_CERT_FILE`; Erlang/Hex bundle their own CA
+store and don't). Symptoms and fixes, in escalating order:
+
+1. `mix local.hex --force` fails (`bad_status_code` / `unknown_ca`):
+   fetch the official archive with curl and install it from the local
+   file, verifying its checksum against the manifest:
+
+   ```shell
+   curl -fsSL -o /tmp/hex-1.x.csv https://builds.hex.pm/installs/hex-1.x.csv
+   # pick the newest line whose Elixir version <= yours, then:
+   curl -fsSL -o /tmp/hex.ez https://builds.hex.pm/installs/<elixir>/hex-<version>.ez
+   echo "<sha512-from-csv>  /tmp/hex.ez" | sha512sum -c -
+   mix archive.install /tmp/hex.ez --force
+   ```
+
+2. `mix deps.get` fails with `unknown_ca`: point Hex at the system CA
+   bundle:
+
+   ```shell
+   export HEX_CACERTS_PATH=/etc/ssl/certs/ca-certificates.crt
+   ```
+
+3. `mix deps.get` still fails with upstream connection resets: mirror
+   the few locked packages with curl (which the proxy tolerates) and
+   serve them to Hex locally. Registry records and tarballs are
+   signed, so this does not weaken verification:
+
+   ```shell
+   mkdir -p /tmp/hexmirror/packages /tmp/hexmirror/tarballs
+   # for each `"name": {:hex, :name, "version", ...}` in mix.lock:
+   curl -fsSL -o /tmp/hexmirror/packages/$name https://repo.hex.pm/packages/$name
+   curl -fsSL -o /tmp/hexmirror/tarballs/$name-$ver.tar \
+     https://repo.hex.pm/tarballs/$name-$ver.tar
+   (cd /tmp/hexmirror && python3 -m http.server 8765 --bind 127.0.0.1 &)
+   HEX_MIRROR=http://127.0.0.1:8765 mix deps.get
+   ```
+
+## Build, test, and checks
+
+CI runs all of these; keep them green:
+
+```shell
+mix deps.get
+mix test                      # full suite incl. doctests + property tests
+mix format --check-formatted  # enforced by CI
+mix dialyzer                  # enforced by CI (slow first run: builds PLT)
+mix credo --strict            # advisory, not in CI; avoid adding new issues
+```
+
+Notes:
+
+* `MIX_ENV=test` avoids compiling dev-only deps (`ex_doc`, `dialyxir`)
+  when you only need the test suite.
+* The benchmark suite under `bench/` is a standalone project; it is not
+  needed for development and pulls extra deps - skip it unless asked.
+* Test data lives in `test/_data/` (real torrent files) and
+  `test/bencode_test_suite/` (accept/reject conformance vectors).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -53,6 +53,17 @@ edge-case behaviors changed, so this is a major release.
 
 ### Added
 
+* `Bento.Magnet`: a magnet URI codec for BitTorrent (BEP-9), covering
+  v2 info-hashes (BEP-52) and select-only (BEP-53). `parse/1` strictly
+  decodes magnet links into a struct (raw-binary info-hashes from hex
+  or base32, trackers, web seeds, peers, select-only indices, and
+  more), `to_string/1` (and `String.Chars`) renders them, and
+  `from_torrent/1` (also `Bento.magnet/1`) builds a magnet link
+  straight from a `.torrent` file's bytes.
+* `Bento.Metainfo.info_hash/1` and `Bento.Metainfo.info_hash_v2/1`
+  (plus `!` variants): the v1 (SHA-1) and v2 (SHA-256) info-hashes of
+  a metainfo file, computed over the exact bytes of its info
+  dictionary - correct even for non-canonical files.
 * `:keys` decode option: `:strings` (default), `:atoms`, `:atoms!`, or
   a custom function applied to every dictionary key.
 * `:strings` decode option: `:reference` (default) returns

--- a/README.md
+++ b/README.md
@@ -139,6 +139,28 @@ iex> Bento.decode!("d6:family4:Folz5:given6:Rodneye", as: %Name{})
 %Name{family: "Folz", given: "Rodney"}
 ```
 
+### Magnet links
+
+`Bento.Magnet` is a magnet URI codec for BitTorrent (BEP-9), covering v2 info-hashes (BEP-52) and select-only (BEP-53). `Bento.magnet!/1` builds a magnet link from a `.torrent` file:
+
+```elixir
+iex> File.read!("./test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent") |> Bento.magnet!() |> to_string()
+"magnet:?xt=urn:btih:33395da120c9a4758e896ded4dec5f2495c9973f&dn=ubuntu-14.04.4-desktop-amd64.iso&xl=1069547520&tr=http%3A%2F%2Ftorrent.ubuntu.com%3A6969%2Fannounce&tr=http%3A%2F%2Fipv6.torrent.ubuntu.com%3A6969%2Fannounce"
+```
+
+The info-hash is computed over the **exact bytes** of the file's info dictionary (via `dicts: :ordered`), so it is correct even for non-canonical files; `Bento.Metainfo.info_hash/1` and `Bento.Metainfo.info_hash_v2/1` expose the hashes directly. Parsing is as strict as the rest of Bento - malformed hashes, percent-encoding, ports, and repeated single-valued parameters are rejected with descriptive errors:
+
+```elixir
+iex> Bento.Magnet.parse!("magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&dn=Example&so=0,2,4-6")
+%Bento.Magnet{
+  info_hash: <<193, 47, 225, 192, 107, 186, 37, 74, 157, 201, 245, 25, 179,
+    53, 170, 124, 19, 103, 168, 138>>,
+  display_name: "Example",
+  select_only: [0, 2, 4..6],
+  ...
+}
+```
+
 ## Testing
 
 Beyond unit tests, Bento is tested against:

--- a/lib/bento.ex
+++ b/lib/bento.ex
@@ -5,7 +5,7 @@ defmodule Bento do
   This module contains high-level methods to encode and decode Bencoded data.
   """
 
-  alias Bento.{Encoder, Decoder, Metainfo}
+  alias Bento.{Encoder, Decoder, Magnet, Metainfo}
 
   @doc """
   Bencode a value.
@@ -180,4 +180,28 @@ defmodule Bento do
     decoded = decode!(iodata, as: %Metainfo.Torrent{})
     struct(decoded, info: Metainfo.info!(decoded))
   end
+
+  @doc """
+  Build a magnet link from the raw bytes of a torrent metainfo file.
+
+  The info-hash is computed over the exact bytes of the info dictionary
+  as they appear in the input. See `Bento.Magnet.from_torrent/1`.
+  """
+  @spec magnet(iodata()) :: {:ok, Magnet.t()} | failure
+        when failure: {:error, Bento.MagnetError.t() | Bento.SyntaxError.t()}
+  def magnet(iodata), do: Magnet.from_torrent(iodata)
+
+  @doc """
+  Like `magnet/1`, but raises on error.
+
+      iex> File.read!("test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent")
+      ...> |> Bento.magnet!()
+      ...> |> to_string()
+      "magnet:?xt=urn:btih:33395da120c9a4758e896ded4dec5f2495c9973f" <>
+        "&dn=ubuntu-14.04.4-desktop-amd64.iso&xl=1069547520" <>
+        "&tr=http%3A%2F%2Ftorrent.ubuntu.com%3A6969%2Fannounce" <>
+        "&tr=http%3A%2F%2Fipv6.torrent.ubuntu.com%3A6969%2Fannounce"
+  """
+  @spec magnet!(iodata()) :: Magnet.t() | no_return()
+  def magnet!(iodata), do: Magnet.from_torrent!(iodata)
 end

--- a/lib/bento/magnet.ex
+++ b/lib/bento/magnet.ex
@@ -61,10 +61,12 @@ defmodule Bento.Magnet do
       `urn:btih:` (40 hex or 32 base32 characters) or `urn:btmh:`
       (a sha2-256 multihash) topic; other URN namespaces are errors,
     * repeated single-valued parameters (`xt` of the same version,
-      `dn`, `xl`, `so`) are errors, as are out-of-range ports, malformed
-      percent-encoding, and non-numeric lengths and indices,
+      `dn`, `xl`, `so`) are errors, as are out-of-range ports,
+      unbracketed IPv6 peer addresses, malformed percent-encoding, and
+      non-numeric lengths and indices,
     * integer parameters are limited to 20 digits, so adversarial input
-      cannot force large big-integer conversions.
+      cannot force large big-integer conversions. The same bounds apply
+      when rendering, so rendered URIs always parse back.
 
   Unknown parameters are ignored. Parameters with empty values are
   ignored. Numbered parameters (`tr.1`, `tr.2`, ...) are treated as
@@ -102,8 +104,10 @@ defmodule Bento.Magnet do
             select_only: [],
             peers: []
 
-  # Bounds integer parameters (xl, so). 20 digits covers any 64-bit size.
+  # Bounds integer parameters (xl, so) when parsing and rendering, so
+  # rendered URIs always parse back. 20 digits covers any 64-bit size.
   @max_integer_digits 20
+  @max_integer_value Integer.pow(10, @max_integer_digits)
 
   @doc """
   Parse a magnet URI.
@@ -182,7 +186,8 @@ defmodule Bento.Magnet do
         magnet
 
       [key, value] ->
-        put_param(magnet, key |> decode!(pair) |> strip_index(), decode!(value, pair))
+        key = key |> decode!(pair) |> strip_index()
+        put_param(magnet, key, decode!(value, pair))
     end
   end
 
@@ -344,12 +349,20 @@ defmodule Bento.Magnet do
   end
 
   defp peer!(value) do
-    with [host, port] when host != "" <- split_host_port(value),
+    with [host, port] <- split_host_port(value),
+         true <- valid_peer_host?(host),
          port when port in 1..65_535 <- port_number(port) do
       value
     else
       _ -> raise MagnetError, message: "Invalid peer address (x.pe): #{bound(value)}"
     end
+  end
+
+  # BEP-9 hosts: a hostname or IPv4 literal (no colons), or a bracketed
+  # IPv6 literal - unbracketed IPv6 would be ambiguous with the port.
+  defp valid_peer_host?(host) do
+    Regex.match?(~r/^\[[^\[\]]+\]\z/, host) or
+      (host != "" and not String.contains?(host, ["[", "]", ":"]))
   end
 
   # The port comes after the last colon: "host:port", "ipv4:port" or
@@ -361,7 +374,9 @@ defmodule Bento.Magnet do
 
       matches ->
         {pos, 1} = List.last(matches)
-        [binary_part(value, 0, pos), binary_part(value, pos + 1, byte_size(value) - pos - 1)]
+        host = binary_part(value, 0, pos)
+        port = binary_part(value, pos + 1, byte_size(value) - pos - 1)
+        [host, port]
     end
   end
 
@@ -384,7 +399,18 @@ defmodule Bento.Magnet do
   defp duplicate(param), do: "Duplicate parameter: #{param}"
 
   # Bounds inspected values in error messages: non-printable binaries
-  # render one byte per element, so :limit must stay small.
+  # render one byte per element, so :limit must stay small, and inspect
+  # does not bound integer digits at all.
+  defp bound(value) when is_integer(value) do
+    digits = Integer.to_string(value)
+
+    if byte_size(digits) > 32 do
+      binary_part(digits, 0, 32) <> "..."
+    else
+      digits
+    end
+  end
+
   defp bound(value), do: inspect(value, printable_limit: 32, limit: 8)
 
   @doc """
@@ -456,11 +482,17 @@ defmodule Bento.Magnet do
     do: raise(MagnetError, message: "#{key} must be a string, got: #{bound(value)}")
 
   defp length_param(nil), do: []
-  defp length_param(length) when is_integer(length) and length >= 0, do: ["xl=#{length}"]
 
-  defp length_param(length),
-    do:
-      raise(MagnetError, message: "length must be a non-negative integer, got: #{bound(length)}")
+  defp length_param(length)
+       when is_integer(length) and length >= 0 and length < @max_integer_value,
+       do: ["xl=#{length}"]
+
+  defp length_param(length) do
+    raise MagnetError,
+      message:
+        "length must be a non-negative integer of at most " <>
+          "#{@max_integer_digits} digits, got: #{bound(length)}"
+  end
 
   defp list_params(key, values, field) when is_list(values) do
     Enum.flat_map(values, fn
@@ -505,17 +537,19 @@ defmodule Bento.Magnet do
   defp select_only_param(items),
     do: raise(MagnetError, message: "select_only must be a list, got: #{bound(items)}")
 
-  defp select_item_string(index) when is_integer(index) and index >= 0,
-    do: Integer.to_string(index)
+  defp select_item_string(index)
+       when is_integer(index) and index >= 0 and index < @max_integer_value,
+       do: Integer.to_string(index)
 
-  defp select_item_string(first..last//1 = _range) when first >= 0 and first <= last,
-    do: "#{first}-#{last}"
+  defp select_item_string(first..last//1 = _range)
+       when first >= 0 and first <= last and last < @max_integer_value,
+       do: "#{first}-#{last}"
 
   defp select_item_string(item) do
     raise MagnetError,
       message:
-        "select_only items must be non-negative integers or ascending ranges, " <>
-          "got: #{bound(item)}"
+        "select_only items must be non-negative integers or ascending ranges " <>
+          "of at most #{@max_integer_digits} digits, got: #{bound(item)}"
   end
 
   defp peer_params(peers) when is_list(peers) do
@@ -564,7 +598,8 @@ defmodule Bento.Magnet do
   Bencoding, and `{:error, %Bento.MagnetError{}}` when it is not a
   torrent metainfo dictionary.
   """
-  @spec from_torrent(iodata()) :: {:ok, t()} | {:error, MagnetError.t() | Bento.SyntaxError.t()}
+  @spec from_torrent(iodata()) :: {:ok, t()} | failure
+        when failure: {:error, MagnetError.t() | Bento.SyntaxError.t()}
   def from_torrent(iodata) do
     with {:ok, meta} <- Bento.decode(iodata, dicts: :ordered),
          {:ok, info} <- fetch_info(meta) do
@@ -646,7 +681,10 @@ defmodule Bento.Magnet do
          :error <- file_tree_length(info) do
       nil
     else
-      {:ok, length} -> length
+      # Lengths past the rendering bound are dropped: xl is auxiliary,
+      # and the struct must stay renderable.
+      {:ok, length} when length < @max_integer_value -> length
+      {:ok, _absurd} -> nil
     end
   end
 
@@ -658,19 +696,23 @@ defmodule Bento.Magnet do
   end
 
   defp multi_file_length(info) do
-    with {:ok, files} when is_list(files) <- OrderedDict.fetch(info, "files") do
-      Enum.reduce_while(files, {:ok, 0}, fn
-        %OrderedDict{} = file, {:ok, total} ->
-          case single_file_length(file) do
-            {:ok, length} -> {:cont, {:ok, total + length}}
-            :error -> {:halt, :error}
-          end
-
-        _other, _acc ->
-          {:halt, :error}
-      end)
-    else
+    case OrderedDict.fetch(info, "files") do
+      {:ok, files} when is_list(files) -> total_file_lengths(files)
       _ -> :error
+    end
+  end
+
+  defp total_file_lengths(files) do
+    Enum.reduce_while(files, {:ok, 0}, fn
+      %OrderedDict{} = file, {:ok, total} -> add_file_length(file, total)
+      _other, _acc -> {:halt, :error}
+    end)
+  end
+
+  defp add_file_length(file, total) do
+    case single_file_length(file) do
+      {:ok, length} -> {:cont, {:ok, total + length}}
+      :error -> {:halt, :error}
     end
   end
 
@@ -686,20 +728,21 @@ defmodule Bento.Magnet do
   defp tree_length(%OrderedDict{} = node) do
     Enum.reduce_while(node, {:ok, 0}, fn
       {"", %OrderedDict{} = file}, {:ok, total} ->
-        case single_file_length(file) do
-          {:ok, length} -> {:cont, {:ok, total + length}}
-          :error -> {:halt, :error}
-        end
+        add_file_length(file, total)
 
       {_name, %OrderedDict{} = child}, {:ok, total} ->
-        case tree_length(child) do
-          {:ok, length} -> {:cont, {:ok, total + length}}
-          :error -> {:halt, :error}
-        end
+        add_tree_length(child, total)
 
       _other, _acc ->
         {:halt, :error}
     end)
+  end
+
+  defp add_tree_length(child, total) do
+    case tree_length(child) do
+      {:ok, length} -> {:cont, {:ok, total + length}}
+      :error -> {:halt, :error}
+    end
   end
 
   defp trackers(meta) do
@@ -718,9 +761,14 @@ defmodule Bento.Magnet do
       end
 
     case {announce_list, OrderedDict.fetch(meta, "announce")} do
-      {[_ | _], _} -> announce_list
-      {[], {:ok, announce}} when is_binary(announce) and announce != "" -> [announce]
-      _ -> []
+      {[_ | _], _} ->
+        announce_list
+
+      {[], {:ok, announce}} when is_binary(announce) and announce != "" ->
+        [announce]
+
+      _ ->
+        []
     end
   end
 

--- a/lib/bento/magnet.ex
+++ b/lib/bento/magnet.ex
@@ -606,7 +606,8 @@ defmodule Bento.Magnet do
   `info_hash_v2`, and hybrid torrents both. The display name, length,
   trackers (`announce-list` falling back to `announce`), and web seeds
   (`url-list`) are carried over when present, as copies - keeping the
-  returned struct does not retain the input binary.
+  returned struct does not retain the input binary. BEP-47 padding
+  files do not count toward the length.
 
       iex> data = Bento.encode!(%{
       ...>   "announce" => "http://tracker.example.com/announce",
@@ -740,9 +741,22 @@ defmodule Bento.Magnet do
   end
 
   defp add_file_length(file, total) do
-    case single_file_length(file) do
-      {:ok, length} -> {:cont, {:ok, total + length}}
-      :error -> {:halt, :error}
+    if padding_file?(file) do
+      {:cont, {:ok, total}}
+    else
+      case single_file_length(file) do
+        {:ok, length} -> {:cont, {:ok, total + length}}
+        :error -> {:halt, :error}
+      end
+    end
+  end
+
+  # BEP-47: an "attr" containing "p" marks a padding file - alignment
+  # filler, not content - so it does not count toward the exact length.
+  defp padding_file?(file) do
+    case OrderedDict.fetch(file, "attr") do
+      {:ok, attr} when is_binary(attr) -> String.contains?(attr, "p")
+      _ -> false
     end
   end
 

--- a/lib/bento/magnet.ex
+++ b/lib/bento/magnet.ex
@@ -1,0 +1,737 @@
+defmodule Bento.MagnetError do
+  @moduledoc """
+  Raised when parsing or rendering an invalid magnet URI.
+  """
+
+  @type t :: %__MODULE__{message: String.t()}
+
+  defexception [:message]
+end
+
+defmodule Bento.Magnet do
+  @moduledoc """
+  A magnet URI codec for BitTorrent (BEP-9), including v2 info-hashes
+  (BEP-52) and the select-only extension (BEP-53).
+
+  A magnet link identifies a torrent by its info-hash instead of a
+  metainfo file. `parse/1` decodes a magnet URI into a struct, and
+  `to_string/1` (also available via the `String.Chars` protocol) renders
+  one. `from_torrent/1` builds a magnet link from the raw bytes of a
+  `.torrent` file, hashing the info dictionary exactly as it appears in
+  the input.
+
+      iex> {:ok, magnet} = Bento.Magnet.parse(
+      ...>   "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a" <>
+      ...>     "&dn=Example+File&tr=udp%3A%2F%2Ftracker.example.com%3A80")
+      iex> magnet.display_name
+      "Example File"
+      iex> Base.encode16(magnet.info_hash, case: :lower)
+      "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
+      iex> magnet.trackers
+      ["udp://tracker.example.com:80"]
+
+  ## Fields
+
+  Struct fields map to magnet URI parameters as follows:
+
+  | Field                 | Parameter | Notes                                          |
+  |-----------------------|-----------|------------------------------------------------|
+  | `info_hash`           | `xt=urn:btih:` | v1 info-hash as a raw 20-byte binary      |
+  | `info_hash_v2`        | `xt=urn:btmh:` | v2 (SHA-256) info-hash as a raw 32-byte binary |
+  | `display_name`        | `dn`      |                                                |
+  | `length`              | `xl`      | size in bytes                                  |
+  | `trackers`            | `tr`      |                                                |
+  | `web_seeds`           | `ws`      | BEP-19 HTTP seeds                              |
+  | `acceptable_sources`  | `as`      | URL to the file content                        |
+  | `exact_sources`       | `xs`      | URL to the metainfo file                       |
+  | `keywords`            | `kt`      | list of search words                           |
+  | `select_only`         | `so`      | BEP-53 file indices: integers and `Range`s     |
+  | `peers`               | `x.pe`    | `"host:port"` strings                          |
+
+  Info-hashes are held as raw binaries - the form used by the wire
+  protocol, trackers, and the DHT - and accepted in hex or RFC 3548
+  base32 when parsing. Rendering normalizes them to lowercase hex.
+
+  ## Strictness
+
+  In keeping with the rest of Bento, parsing rejects malformed input
+  with descriptive errors rather than guessing:
+
+    * the `xt` parameter is required and must carry a well-formed
+      `urn:btih:` (40 hex or 32 base32 characters) or `urn:btmh:`
+      (a sha2-256 multihash) topic; other URN namespaces are errors,
+    * repeated single-valued parameters (`xt` of the same version,
+      `dn`, `xl`, `so`) are errors, as are out-of-range ports, malformed
+      percent-encoding, and non-numeric lengths and indices,
+    * integer parameters are limited to 20 digits, so adversarial input
+      cannot force large big-integer conversions.
+
+  Unknown parameters are ignored. Parameters with empty values are
+  ignored. Numbered parameters (`tr.1`, `tr.2`, ...) are treated as
+  their base parameter, in document order.
+  """
+
+  alias Bento.MagnetError
+  alias Bento.OrderedDict
+
+  @type select_item :: non_neg_integer() | Range.t()
+
+  @type t :: %__MODULE__{
+          info_hash: <<_::160>> | nil,
+          info_hash_v2: <<_::256>> | nil,
+          display_name: String.t() | nil,
+          length: non_neg_integer() | nil,
+          trackers: [String.t()],
+          web_seeds: [String.t()],
+          acceptable_sources: [String.t()],
+          exact_sources: [String.t()],
+          keywords: [String.t()],
+          select_only: [select_item()],
+          peers: [String.t()]
+        }
+
+  defstruct info_hash: nil,
+            info_hash_v2: nil,
+            display_name: nil,
+            length: nil,
+            trackers: [],
+            web_seeds: [],
+            acceptable_sources: [],
+            exact_sources: [],
+            keywords: [],
+            select_only: [],
+            peers: []
+
+  # Bounds integer parameters (xl, so). 20 digits covers any 64-bit size.
+  @max_integer_digits 20
+
+  @doc """
+  Parse a magnet URI.
+
+      iex> {:ok, magnet} = Bento.Magnet.parse("magnet:?xt=urn:btih:" <>
+      ...>   "C12FE1C06BBA254A9DC9F519B335AA7C1367A88A&so=0,2,4-6")
+      iex> magnet.select_only
+      [0, 2, 4..6]
+
+  Returns `{:error, %Bento.MagnetError{}}` on malformed input:
+
+      iex> {:error, error} = Bento.Magnet.parse("magnet:?xt=urn:btih:tooshort")
+      iex> error.message
+      ~S(Invalid v1 info-hash, expected 40 hex or 32 base32 characters: "tooshort")
+  """
+  @spec parse(String.t()) :: {:ok, t()} | {:error, MagnetError.t()}
+  def parse(uri) when is_binary(uri) do
+    {:ok, parse!(uri)}
+  rescue
+    exception in [MagnetError] -> {:error, exception}
+  end
+
+  @doc """
+  Parse a magnet URI, raising `Bento.MagnetError` on malformed input.
+
+      iex> Bento.Magnet.parse!("magnet:?xt=urn:btih:" <>
+      ...>   "c12fe1c06bba254a9dc9f519b335aa7c1367a88a").info_hash
+      Base.decode16!("c12fe1c06bba254a9dc9f519b335aa7c1367a88a", case: :lower)
+  """
+  @spec parse!(String.t()) :: t() | no_return()
+  def parse!(uri) when is_binary(uri) do
+    magnet =
+      uri
+      |> String.trim()
+      |> query!()
+      |> String.split("&")
+      |> Enum.reduce(%__MODULE__{}, &put_pair(&2, &1))
+
+    if magnet.info_hash == nil and magnet.info_hash_v2 == nil do
+      raise MagnetError, message: "Missing exact topic: no xt=urn:btih: or xt=urn:btmh: parameter"
+    end
+
+    %{
+      magnet
+      | trackers: Enum.reverse(magnet.trackers),
+        web_seeds: Enum.reverse(magnet.web_seeds),
+        acceptable_sources: Enum.reverse(magnet.acceptable_sources),
+        exact_sources: Enum.reverse(magnet.exact_sources),
+        keywords: Enum.reverse(magnet.keywords),
+        peers: Enum.reverse(magnet.peers)
+    }
+  end
+
+  defp query!(uri) do
+    case String.split(uri, "?", parts: 2) do
+      [scheme, query] when byte_size(scheme) == 7 ->
+        if String.downcase(scheme) == "magnet:" do
+          # A raw "#" ends the query: fragments are not part of it.
+          query |> String.split("#", parts: 2) |> hd()
+        else
+          raise MagnetError, message: "Not a magnet URI: #{bound(uri)}"
+        end
+
+      _ ->
+        raise MagnetError, message: "Not a magnet URI: #{bound(uri)}"
+    end
+  end
+
+  defp put_pair(magnet, pair) do
+    case String.split(pair, "=", parts: 2) do
+      # Bare tokens and empty values carry no information.
+      [_key] ->
+        magnet
+
+      [_key, ""] ->
+        magnet
+
+      [key, value] ->
+        put_param(magnet, key |> decode!(pair) |> strip_index(), decode!(value, pair))
+    end
+  end
+
+  defp decode!(component, pair) do
+    case decode_component(component, <<>>) do
+      :error ->
+        raise MagnetError, message: "Malformed percent-encoding in parameter: #{bound(pair)}"
+
+      decoded ->
+        decoded
+    end
+  end
+
+  defguardp is_hex(c) when c in ?0..?9 or c in ?a..?f or c in ?A..?F
+
+  # www-form decoding: "+" is a space and "%" must start two hex digits.
+  # Done by hand because `URI.decode_www_form/1` passes malformed escapes
+  # through unchanged (and has changed behavior across Elixir versions),
+  # while Bento rejects malformed input.
+  defp decode_component(<<?%, hi, lo, rest::binary>>, acc) when is_hex(hi) and is_hex(lo) do
+    decode_component(rest, <<acc::binary, hex_digit(hi) * 16 + hex_digit(lo)>>)
+  end
+
+  defp decode_component(<<?%, _rest::binary>>, _acc), do: :error
+
+  defp decode_component(<<?+, rest::binary>>, acc),
+    do: decode_component(rest, <<acc::binary, ?\s>>)
+
+  defp decode_component(<<byte, rest::binary>>, acc),
+    do: decode_component(rest, <<acc::binary, byte>>)
+
+  defp decode_component(<<>>, acc), do: acc
+
+  defp hex_digit(c) when c in ?0..?9, do: c - ?0
+  defp hex_digit(c) when c in ?a..?f, do: c - ?a + 10
+  defp hex_digit(c) when c in ?A..?F, do: c - ?A + 10
+
+  # Numbered parameters ("tr.1") count as their base parameter. The digit
+  # requirement keeps dotted names like "x.pe" intact.
+  defp strip_index(key) do
+    case Regex.run(~r/^(.+)\.\d+\z/, key) do
+      [_, base] -> base
+      nil -> key
+    end
+  end
+
+  defp put_param(magnet, "xt", value), do: put_topic(magnet, value)
+
+  defp put_param(%{display_name: nil} = magnet, "dn", value),
+    do: %{magnet | display_name: value}
+
+  defp put_param(_magnet, "dn", _value), do: raise(MagnetError, message: duplicate("dn"))
+
+  defp put_param(%{length: nil} = magnet, "xl", value),
+    do: %{magnet | length: integer!(value, "Invalid exact length (xl)")}
+
+  defp put_param(_magnet, "xl", _value), do: raise(MagnetError, message: duplicate("xl"))
+
+  defp put_param(magnet, "tr", value), do: %{magnet | trackers: [value | magnet.trackers]}
+  defp put_param(magnet, "ws", value), do: %{magnet | web_seeds: [value | magnet.web_seeds]}
+
+  defp put_param(magnet, "as", value),
+    do: %{magnet | acceptable_sources: [value | magnet.acceptable_sources]}
+
+  defp put_param(magnet, "xs", value),
+    do: %{magnet | exact_sources: [value | magnet.exact_sources]}
+
+  defp put_param(magnet, "kt", value),
+    do: %{magnet | keywords: Enum.reverse(String.split(value)) ++ magnet.keywords}
+
+  defp put_param(%{select_only: []} = magnet, "so", value),
+    do: %{magnet | select_only: select_only!(value)}
+
+  defp put_param(_magnet, "so", _value), do: raise(MagnetError, message: duplicate("so"))
+
+  defp put_param(magnet, "x.pe", value),
+    do: %{magnet | peers: [peer!(value) | magnet.peers]}
+
+  defp put_param(magnet, _unknown, _value), do: magnet
+
+  defp put_topic(magnet, <<urn::binary-size(9), rest::binary>> = value) do
+    case String.downcase(urn) do
+      "urn:btih:" -> put_info_hash(magnet, btih!(rest))
+      "urn:btmh:" -> put_info_hash_v2(magnet, btmh!(rest))
+      _ -> raise MagnetError, message: unsupported_topic(value)
+    end
+  end
+
+  defp put_topic(_magnet, value), do: raise(MagnetError, message: unsupported_topic(value))
+
+  defp unsupported_topic(value),
+    do: "Unsupported exact topic (xt), expected urn:btih: or urn:btmh: - got: #{bound(value)}"
+
+  defp put_info_hash(%{info_hash: nil} = magnet, hash), do: %{magnet | info_hash: hash}
+
+  defp put_info_hash(_magnet, _hash),
+    do: raise(MagnetError, message: duplicate("xt (urn:btih)"))
+
+  defp put_info_hash_v2(%{info_hash_v2: nil} = magnet, hash), do: %{magnet | info_hash_v2: hash}
+
+  defp put_info_hash_v2(_magnet, _hash),
+    do: raise(MagnetError, message: duplicate("xt (urn:btmh)"))
+
+  defp btih!(string) when byte_size(string) == 40 do
+    case Base.decode16(string, case: :mixed) do
+      {:ok, hash} -> hash
+      :error -> raise MagnetError, message: "Invalid v1 info-hash, bad hex: #{bound(string)}"
+    end
+  end
+
+  defp btih!(string) when byte_size(string) == 32 do
+    case Base.decode32(string, case: :mixed, padding: false) do
+      {:ok, hash} -> hash
+      :error -> raise MagnetError, message: "Invalid v1 info-hash, bad base32: #{bound(string)}"
+    end
+  end
+
+  defp btih!(string) do
+    raise MagnetError,
+      message: "Invalid v1 info-hash, expected 40 hex or 32 base32 characters: #{bound(string)}"
+  end
+
+  # BEP-52: a multihash in hex. Only sha2-256 (code 0x12, length 0x20) is
+  # defined for BitTorrent.
+  defp btmh!(string) do
+    case Base.decode16(string, case: :mixed) do
+      {:ok, <<0x12, 0x20, hash::binary-size(32)>>} ->
+        hash
+
+      {:ok, _other} ->
+        raise MagnetError,
+          message: "Unsupported v2 info-hash, expected a sha2-256 multihash: #{bound(string)}"
+
+      :error ->
+        raise MagnetError, message: "Invalid v2 info-hash, bad hex: #{bound(string)}"
+    end
+  end
+
+  # BEP-53: comma-separated indices and ranges, like "0,2,4-6".
+  defp select_only!(value) do
+    for item <- String.split(value, ","), do: select_item!(item, value)
+  end
+
+  defp select_item!(item, value) do
+    case String.split(item, "-", parts: 2) do
+      [index] ->
+        integer!(index, "Invalid select-only (so) value", value)
+
+      [first, last] ->
+        first = integer!(first, "Invalid select-only (so) value", value)
+        last = integer!(last, "Invalid select-only (so) value", value)
+
+        if first > last do
+          raise MagnetError, message: "Invalid select-only (so) range: #{bound(value)}"
+        end
+
+        first..last
+    end
+  end
+
+  defp peer!(value) do
+    with [host, port] when host != "" <- split_host_port(value),
+         port when port in 1..65_535 <- port_number(port) do
+      value
+    else
+      _ -> raise MagnetError, message: "Invalid peer address (x.pe): #{bound(value)}"
+    end
+  end
+
+  # The port comes after the last colon: "host:port", "ipv4:port" or
+  # "[ipv6]:port" (BEP-9).
+  defp split_host_port(value) do
+    case :binary.matches(value, ":") do
+      [] ->
+        :error
+
+      matches ->
+        {pos, 1} = List.last(matches)
+        [binary_part(value, 0, pos), binary_part(value, pos + 1, byte_size(value) - pos - 1)]
+    end
+  end
+
+  # Note `\z`, not `$`: the latter would also match just before a trailing
+  # newline, letting values like "42\n" through to `String.to_integer/1`.
+  defp port_number(string) do
+    if string =~ ~r/^\d{1,5}\z/, do: String.to_integer(string), else: :error
+  end
+
+  defp integer!(value, error), do: integer!(value, error, value)
+
+  defp integer!(value, error, context) do
+    if byte_size(value) <= @max_integer_digits and value =~ ~r/^\d+\z/ do
+      String.to_integer(value)
+    else
+      raise MagnetError, message: "#{error}: #{bound(context)}"
+    end
+  end
+
+  defp duplicate(param), do: "Duplicate parameter: #{param}"
+
+  # Bounds inspected values in error messages: non-printable binaries
+  # render one byte per element, so :limit must stay small.
+  defp bound(value), do: inspect(value, printable_limit: 32, limit: 8)
+
+  @doc """
+  Render a magnet URI, raising `Bento.MagnetError` if the struct holds
+  no info-hash or otherwise invalid values.
+
+  Info-hashes are emitted as lowercase hex, values are percent-encoded,
+  and empty values are omitted. Also available through the
+  `String.Chars` protocol, so magnet structs work in string
+  interpolation.
+
+      iex> magnet = %Bento.Magnet{
+      ...>   info_hash: Base.decode16!("C12FE1C06BBA254A9DC9F519B335AA7C1367A88A"),
+      ...>   display_name: "Example File",
+      ...>   trackers: ["udp://tracker.example.com:80"]
+      ...> }
+      iex> Bento.Magnet.to_string(magnet)
+      "magnet:?xt=urn:btih:c12fe1c06bba254a9dc9f519b335aa7c1367a88a&dn=Example+File&tr=udp%3A%2F%2Ftracker.example.com%3A80"
+  """
+  @spec to_string(t()) :: String.t() | no_return()
+  def to_string(%__MODULE__{} = magnet) do
+    params =
+      [
+        topic_params(magnet),
+        scalar_param("dn", magnet.display_name),
+        length_param(magnet.length),
+        list_params("tr", magnet.trackers, "trackers"),
+        list_params("ws", magnet.web_seeds, "web_seeds"),
+        list_params("as", magnet.acceptable_sources, "acceptable_sources"),
+        list_params("xs", magnet.exact_sources, "exact_sources"),
+        keywords_param(magnet.keywords),
+        select_only_param(magnet.select_only),
+        peer_params(magnet.peers)
+      ]
+      |> Enum.concat()
+
+    "magnet:?" <> Enum.join(params, "&")
+  end
+
+  defp topic_params(%{info_hash: nil, info_hash_v2: nil}) do
+    raise MagnetError, message: "Cannot render a magnet URI without an info-hash"
+  end
+
+  defp topic_params(%{info_hash: v1, info_hash_v2: v2}) do
+    btih =
+      case v1 do
+        nil -> []
+        <<_::160>> -> ["xt=urn:btih:" <> Base.encode16(v1, case: :lower)]
+        _other -> raise MagnetError, message: "info_hash must be a 20-byte binary"
+      end
+
+    btmh =
+      case v2 do
+        nil -> []
+        <<_::256>> -> ["xt=urn:btmh:1220" <> Base.encode16(v2, case: :lower)]
+        _other -> raise MagnetError, message: "info_hash_v2 must be a 32-byte binary"
+      end
+
+    btih ++ btmh
+  end
+
+  defp scalar_param(_key, nil), do: []
+  defp scalar_param(_key, ""), do: []
+
+  defp scalar_param(key, value) when is_binary(value),
+    do: [key <> "=" <> URI.encode_www_form(value)]
+
+  defp scalar_param(key, value),
+    do: raise(MagnetError, message: "#{key} must be a string, got: #{bound(value)}")
+
+  defp length_param(nil), do: []
+  defp length_param(length) when is_integer(length) and length >= 0, do: ["xl=#{length}"]
+
+  defp length_param(length),
+    do:
+      raise(MagnetError, message: "length must be a non-negative integer, got: #{bound(length)}")
+
+  defp list_params(key, values, field) when is_list(values) do
+    Enum.flat_map(values, fn
+      "" -> []
+      value when is_binary(value) -> [key <> "=" <> URI.encode_www_form(value)]
+      value -> raise MagnetError, message: "#{field} must be strings, got: #{bound(value)}"
+    end)
+  end
+
+  defp list_params(_key, values, field),
+    do: raise(MagnetError, message: "#{field} must be a list, got: #{bound(values)}")
+
+  defp keywords_param([]), do: []
+
+  defp keywords_param(keywords) when is_list(keywords) do
+    words =
+      Enum.map(keywords, fn
+        word when is_binary(word) and word != "" ->
+          if word =~ ~r/\s/ do
+            raise MagnetError, message: "keywords must not contain whitespace: #{bound(word)}"
+          end
+
+          word
+
+        word ->
+          raise MagnetError, message: "keywords must be non-empty strings, got: #{bound(word)}"
+      end)
+
+    ["kt=" <> URI.encode_www_form(Enum.join(words, " "))]
+  end
+
+  defp keywords_param(keywords),
+    do: raise(MagnetError, message: "keywords must be a list, got: #{bound(keywords)}")
+
+  defp select_only_param([]), do: []
+
+  defp select_only_param(items) when is_list(items) do
+    # Digits, commas and dashes are query-safe; emitted raw, as BEP-53 shows.
+    ["so=" <> Enum.map_join(items, ",", &select_item_string/1)]
+  end
+
+  defp select_only_param(items),
+    do: raise(MagnetError, message: "select_only must be a list, got: #{bound(items)}")
+
+  defp select_item_string(index) when is_integer(index) and index >= 0,
+    do: Integer.to_string(index)
+
+  defp select_item_string(first..last//1 = _range) when first >= 0 and first <= last,
+    do: "#{first}-#{last}"
+
+  defp select_item_string(item) do
+    raise MagnetError,
+      message:
+        "select_only items must be non-negative integers or ascending ranges, " <>
+          "got: #{bound(item)}"
+  end
+
+  defp peer_params(peers) when is_list(peers) do
+    # Colons and brackets are conventionally left raw in x.pe values.
+    Enum.flat_map(peers, fn
+      "" -> []
+      peer when is_binary(peer) -> ["x.pe=" <> URI.encode(peer, &peer_char?/1)]
+      peer -> raise MagnetError, message: "peers must be strings, got: #{bound(peer)}"
+    end)
+  end
+
+  defp peer_params(peers),
+    do: raise(MagnetError, message: "peers must be a list, got: #{bound(peers)}")
+
+  defp peer_char?(char), do: char in ~c"[]:" or URI.char_unreserved?(char)
+
+  @doc """
+  Build a magnet link from the raw bytes of a torrent metainfo file.
+
+  The info-hash is computed over the **exact bytes** of the file's info
+  dictionary (decoded with `dicts: :ordered` and re-encoded
+  byte-for-byte), so it matches the hash other BitTorrent clients
+  compute even for non-canonical files. This is also why the function
+  takes the file's bytes rather than a decoded `Bento.Metainfo.Torrent`
+  struct: re-encoding a struct that dropped unknown keys would produce
+  the wrong hash.
+
+  v1 torrents get an `info_hash`, v2 (BEP-52) torrents an
+  `info_hash_v2`, and hybrid torrents both. The display name, length,
+  trackers (`announce-list` falling back to `announce`), and web seeds
+  (`url-list`) are carried over when present.
+
+      iex> data = Bento.encode!(%{
+      ...>   "announce" => "http://tracker.example.com/announce",
+      ...>   "info" => %{"name" => "example.txt", "length" => 42,
+      ...>               "piece length" => 16384, "pieces" => <<0::160>>}
+      ...> })
+      iex> {:ok, magnet} = Bento.Magnet.from_torrent(data)
+      iex> "\#{magnet}"
+      "magnet:?xt=urn:btih:d09849a439468af225a96acec4e10d208329ac6e" <>
+        "&dn=example.txt&xl=42&tr=http%3A%2F%2Ftracker.example.com%2Fannounce"
+
+  Returns `{:error, %Bento.SyntaxError{}}` when the input isn't valid
+  Bencoding, and `{:error, %Bento.MagnetError{}}` when it is not a
+  torrent metainfo dictionary.
+  """
+  @spec from_torrent(iodata()) :: {:ok, t()} | {:error, MagnetError.t() | Bento.SyntaxError.t()}
+  def from_torrent(iodata) do
+    with {:ok, meta} <- Bento.decode(iodata, dicts: :ordered),
+         {:ok, info} <- fetch_info(meta) do
+      build_magnet(meta, info)
+    end
+  end
+
+  @doc """
+  Like `from_torrent/1`, but raises on error.
+
+      iex> File.read!("test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent")
+      ...> |> Bento.Magnet.from_torrent!()
+      ...> |> Map.get(:display_name)
+      "ubuntu-14.04.4-desktop-amd64.iso"
+  """
+  @spec from_torrent!(iodata()) :: t() | no_return()
+  def from_torrent!(iodata) do
+    case from_torrent(iodata) do
+      {:ok, magnet} -> magnet
+      {:error, error} -> raise error
+    end
+  end
+
+  defp fetch_info(%OrderedDict{} = meta) do
+    # With duplicate "info" keys the hash would be ambiguous: clients
+    # hashing the raw bytes could disagree on which dictionary they named.
+    case Enum.count(meta, fn {key, _} -> key == "info" end) do
+      1 ->
+        case OrderedDict.fetch(meta, "info") do
+          {:ok, %OrderedDict{} = info} -> {:ok, info}
+          {:ok, _other} -> invalid_metainfo("info is not a dictionary")
+        end
+
+      0 ->
+        invalid_metainfo("missing info dictionary")
+
+      _ ->
+        invalid_metainfo("duplicate info dictionary")
+    end
+  end
+
+  defp fetch_info(_other), do: invalid_metainfo("not a dictionary")
+
+  defp invalid_metainfo(reason) do
+    {:error, %MagnetError{message: "Invalid metainfo file: #{reason}"}}
+  end
+
+  defp build_magnet(meta, info) do
+    info_bytes = Bento.encode!(info)
+    v1? = match?({:ok, _}, OrderedDict.fetch(info, "pieces"))
+    v2? = OrderedDict.fetch(info, "meta version") == {:ok, 2}
+
+    if v1? or v2? do
+      {:ok,
+       %__MODULE__{
+         info_hash: if(v1?, do: :crypto.hash(:sha, info_bytes)),
+         info_hash_v2: if(v2?, do: :crypto.hash(:sha256, info_bytes)),
+         display_name: display_name(info),
+         length: total_length(info),
+         trackers: trackers(meta),
+         web_seeds: web_seeds(meta)
+       }}
+    else
+      invalid_metainfo("missing info.pieces or info.\"meta version\"")
+    end
+  end
+
+  defp display_name(info) do
+    case {OrderedDict.fetch(info, "name.utf-8"), OrderedDict.fetch(info, "name")} do
+      {{:ok, name}, _} when is_binary(name) and name != "" -> name
+      {_, {:ok, name}} when is_binary(name) and name != "" -> name
+      _ -> nil
+    end
+  end
+
+  defp total_length(info) do
+    with :error <- single_file_length(info),
+         :error <- multi_file_length(info),
+         :error <- file_tree_length(info) do
+      nil
+    else
+      {:ok, length} -> length
+    end
+  end
+
+  defp single_file_length(info) do
+    case OrderedDict.fetch(info, "length") do
+      {:ok, length} when is_integer(length) and length >= 0 -> {:ok, length}
+      _ -> :error
+    end
+  end
+
+  defp multi_file_length(info) do
+    with {:ok, files} when is_list(files) <- OrderedDict.fetch(info, "files") do
+      Enum.reduce_while(files, {:ok, 0}, fn
+        %OrderedDict{} = file, {:ok, total} ->
+          case single_file_length(file) do
+            {:ok, length} -> {:cont, {:ok, total + length}}
+            :error -> {:halt, :error}
+          end
+
+        _other, _acc ->
+          {:halt, :error}
+      end)
+    else
+      _ -> :error
+    end
+  end
+
+  # BEP-52 file tree: a file is a `""` key holding its attributes, any
+  # other key is a directory holding a subtree.
+  defp file_tree_length(info) do
+    case OrderedDict.fetch(info, "file tree") do
+      {:ok, %OrderedDict{} = tree} -> tree_length(tree)
+      _ -> :error
+    end
+  end
+
+  defp tree_length(%OrderedDict{} = node) do
+    Enum.reduce_while(node, {:ok, 0}, fn
+      {"", %OrderedDict{} = file}, {:ok, total} ->
+        case single_file_length(file) do
+          {:ok, length} -> {:cont, {:ok, total + length}}
+          :error -> {:halt, :error}
+        end
+
+      {_name, %OrderedDict{} = child}, {:ok, total} ->
+        case tree_length(child) do
+          {:ok, length} -> {:cont, {:ok, total + length}}
+          :error -> {:halt, :error}
+        end
+
+      _other, _acc ->
+        {:halt, :error}
+    end)
+  end
+
+  defp trackers(meta) do
+    announce_list =
+      case OrderedDict.fetch(meta, "announce-list") do
+        {:ok, tiers} when is_list(tiers) ->
+          tiers
+          |> Enum.flat_map(fn
+            tier when is_list(tier) -> Enum.filter(tier, &(is_binary(&1) and &1 != ""))
+            _other -> []
+          end)
+          |> Enum.uniq()
+
+        _ ->
+          []
+      end
+
+    case {announce_list, OrderedDict.fetch(meta, "announce")} do
+      {[_ | _], _} -> announce_list
+      {[], {:ok, announce}} when is_binary(announce) and announce != "" -> [announce]
+      _ -> []
+    end
+  end
+
+  # BEP-19: top-level "url-list", a single URL or a list of them.
+  defp web_seeds(meta) do
+    case OrderedDict.fetch(meta, "url-list") do
+      {:ok, url} when is_binary(url) and url != "" -> [url]
+      {:ok, urls} when is_list(urls) -> Enum.filter(urls, &(is_binary(&1) and &1 != ""))
+      _ -> []
+    end
+  end
+end
+
+defimpl String.Chars, for: Bento.Magnet do
+  def to_string(magnet), do: Bento.Magnet.to_string(magnet)
+end

--- a/lib/bento/magnet.ex
+++ b/lib/bento/magnet.ex
@@ -520,9 +520,11 @@ defmodule Bento.Magnet do
 
   defp peer_params(peers) when is_list(peers) do
     # Colons and brackets are conventionally left raw in x.pe values.
+    # peer!/1 enforces the BEP-9 host:port form, so rendered URIs always
+    # parse back.
     Enum.flat_map(peers, fn
       "" -> []
-      peer when is_binary(peer) -> ["x.pe=" <> URI.encode(peer, &peer_char?/1)]
+      peer when is_binary(peer) -> ["x.pe=" <> URI.encode(peer!(peer), &peer_char?/1)]
       peer -> raise MagnetError, message: "peers must be strings, got: #{bound(peer)}"
     end)
   end

--- a/lib/bento/magnet.ex
+++ b/lib/bento/magnet.ex
@@ -61,9 +61,10 @@ defmodule Bento.Magnet do
       `urn:btih:` (40 hex or 32 base32 characters) or `urn:btmh:`
       (a sha2-256 multihash) topic; other URN namespaces are errors,
     * repeated single-valued parameters (`xt` of the same version,
-      `dn`, `xl`, `so`) are errors, as are out-of-range ports,
-      unbracketed IPv6 peer addresses, malformed percent-encoding, and
-      non-numeric lengths and indices,
+      `dn`, `xl`, `so`) are errors, as are out-of-range ports, peer
+      hosts that are not a hostname, IPv4 literal, or bracketed IPv6
+      literal, malformed percent-encoding, and non-numeric lengths and
+      indices,
     * integer parameters are limited to 20 digits, so adversarial input
       cannot force large big-integer conversions. The same bounds apply
       when rendering, so rendered URIs always parse back.
@@ -358,11 +359,33 @@ defmodule Bento.Magnet do
     end
   end
 
-  # BEP-9 hosts: a hostname or IPv4 literal (no colons), or a bracketed
-  # IPv6 literal - unbracketed IPv6 would be ambiguous with the port.
+  # RFC 1123 hostname: dot-separated alphanumeric labels of up to 63
+  # characters, hyphens allowed inside. IPv4 literals match it too.
+  @peer_label ~S"[a-zA-Z0-9]([a-zA-Z0-9-]{0,61}[a-zA-Z0-9])?"
+  @peer_host_regex Regex.compile!("^#{@peer_label}(\\.#{@peer_label})*\\z")
+
+  # BEP-9 hosts: a hostname or IPv4 literal, or a bracketed IPv6
+  # literal - unbracketed IPv6 would be ambiguous with the port.
+  defp valid_peer_host?(<<"[", rest::binary>>) do
+    case :binary.split(rest, "]") do
+      [inner, ""] -> ipv6_literal?(inner)
+      _ -> false
+    end
+  end
+
   defp valid_peer_host?(host) do
-    Regex.match?(~r/^\[[^\[\]]+\]\z/, host) or
-      (host != "" and not String.contains?(host, ["[", "]", ":"]))
+    byte_size(host) in 1..253 and Regex.match?(@peer_host_regex, host)
+  end
+
+  defp ipv6_literal?(inner) do
+    # The ASCII pre-check keeps to_charlist safe on arbitrary bytes;
+    # parse_strict_address validates the address grammar, and only an
+    # 8-tuple (IPv6) belongs in brackets.
+    Regex.match?(~r/^[0-9A-Fa-f:.]{2,45}\z/, inner) and
+      match?(
+        {:ok, address} when tuple_size(address) == 8,
+        :inet.parse_strict_address(String.to_charlist(inner))
+      )
   end
 
   # The port comes after the last colon: "host:port", "ipv4:port" or
@@ -582,7 +605,8 @@ defmodule Bento.Magnet do
   v1 torrents get an `info_hash`, v2 (BEP-52) torrents an
   `info_hash_v2`, and hybrid torrents both. The display name, length,
   trackers (`announce-list` falling back to `announce`), and web seeds
-  (`url-list`) are carried over when present.
+  (`url-list`) are carried over when present, as copies - keeping the
+  returned struct does not retain the input binary.
 
       iex> data = Bento.encode!(%{
       ...>   "announce" => "http://tracker.example.com/announce",
@@ -647,6 +671,12 @@ defmodule Bento.Magnet do
     {:error, %MagnetError{message: "Invalid metainfo file: #{reason}"}}
   end
 
+  # Decoded strings are sub-binaries into the input (strings: :reference);
+  # copying the few that escape keeps the returned struct from retaining
+  # the whole torrent binary.
+  defp copy(nil), do: nil
+  defp copy(string), do: :binary.copy(string)
+
   defp build_magnet(meta, info) do
     info_bytes = Bento.encode!(info)
     v1? = match?({:ok, _}, OrderedDict.fetch(info, "pieces"))
@@ -657,10 +687,10 @@ defmodule Bento.Magnet do
        %__MODULE__{
          info_hash: if(v1?, do: :crypto.hash(:sha, info_bytes)),
          info_hash_v2: if(v2?, do: :crypto.hash(:sha256, info_bytes)),
-         display_name: display_name(info),
+         display_name: copy(display_name(info)),
          length: total_length(info),
-         trackers: trackers(meta),
-         web_seeds: web_seeds(meta)
+         trackers: Enum.map(trackers(meta), &:binary.copy/1),
+         web_seeds: Enum.map(web_seeds(meta), &:binary.copy/1)
        }}
     else
       invalid_metainfo("missing info.pieces or info.\"meta version\"")

--- a/lib/bento/metainfo.ex
+++ b/lib/bento/metainfo.ex
@@ -86,6 +86,7 @@ defmodule Bento.Metainfo do
   end
 
   alias Bento.Decoder
+  alias Bento.OrderedDict
 
   def info(torrent = %{info: %{"files" => _}}) do
     with {:module, _} <- Code.ensure_loaded(MultiFile) do
@@ -110,6 +111,96 @@ defmodule Bento.Metainfo do
   def info!(torrent) do
     case info(torrent) do
       {:ok, value} -> value
+      {:error, msg} -> raise Bento.MetainfoError, message: msg
+    end
+  end
+
+  @doc """
+  Compute the v1 (SHA-1) info-hash of a torrent metainfo file.
+
+  Takes the raw bencoded bytes of the file - not a decoded
+  `Bento.Metainfo.Torrent` struct, which may have dropped unknown keys
+  and would hash incorrectly. The hash is computed over the exact bytes
+  of the info dictionary as they appear in the input (decoded with
+  `dicts: :ordered` and re-encoded byte-for-byte), so it matches the
+  hash other BitTorrent clients compute even for non-canonical files.
+
+  Returns the hash as a raw 20-byte binary:
+
+      iex> File.read!("test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent")
+      ...> |> Bento.Metainfo.info_hash!()
+      ...> |> Base.encode16(case: :lower)
+      "33395da120c9a4758e896ded4dec5f2495c9973f"
+
+  Returns an error for torrents with no v1 data (BEP-52 v2-only
+  torrents have no `pieces` key); see `info_hash_v2/1` for those.
+  """
+  @spec info_hash(iodata()) :: {:ok, <<_::160>>} | failure
+        when failure: {:error, Bento.SyntaxError.t() | String.t()}
+  def info_hash(metainfo) do
+    with {:ok, info} <- raw_info(metainfo) do
+      case OrderedDict.fetch(info, "pieces") do
+        {:ok, _} -> {:ok, :crypto.hash(:sha, Bento.encode!(info))}
+        :error -> {:error, "Not a v1 torrent: the info dictionary has no pieces key"}
+      end
+    end
+  end
+
+  @doc """
+  Like `info_hash/1`, but raises on error.
+  """
+  @spec info_hash!(iodata()) :: <<_::160>> | no_return()
+  def info_hash!(metainfo), do: unwrap!(info_hash(metainfo))
+
+  @doc """
+  Compute the v2 (SHA-256) info-hash of a BEP-52 torrent metainfo file.
+
+  Takes the raw bencoded bytes of the file, like `info_hash/1`, and
+  returns the hash as a raw 32-byte binary. Returns an error unless the
+  info dictionary declares `meta version` 2 (a v2 or hybrid torrent):
+  for other inputs a SHA-256 of the info dictionary identifies nothing.
+  """
+  @spec info_hash_v2(iodata()) :: {:ok, <<_::256>>} | failure
+        when failure: {:error, Bento.SyntaxError.t() | String.t()}
+  def info_hash_v2(metainfo) do
+    with {:ok, info} <- raw_info(metainfo) do
+      case OrderedDict.fetch(info, "meta version") do
+        {:ok, 2} -> {:ok, :crypto.hash(:sha256, Bento.encode!(info))}
+        _ -> {:error, "Not a v2 torrent: the info dictionary has no meta version 2 key"}
+      end
+    end
+  end
+
+  @doc """
+  Like `info_hash_v2/1`, but raises on error.
+  """
+  @spec info_hash_v2!(iodata()) :: <<_::256>> | no_return()
+  def info_hash_v2!(metainfo), do: unwrap!(info_hash_v2(metainfo))
+
+  defp raw_info(metainfo) do
+    with {:ok, %OrderedDict{} = meta} <- decode_dict(metainfo) do
+      case {Enum.count(meta, fn {key, _} -> key == "info" end), OrderedDict.fetch(meta, "info")} do
+        {1, {:ok, %OrderedDict{} = info}} -> {:ok, info}
+        {1, {:ok, _other}} -> {:error, "Invalid metainfo file: info is not a dictionary"}
+        {0, _} -> {:error, "Invalid metainfo file: missing info dictionary"}
+        # Duplicate keys would make the hash ambiguous.
+        {_, _} -> {:error, "Invalid metainfo file: duplicate info dictionary"}
+      end
+    end
+  end
+
+  defp decode_dict(metainfo) do
+    case Bento.decode(metainfo, dicts: :ordered) do
+      {:ok, %OrderedDict{} = meta} -> {:ok, meta}
+      {:ok, _other} -> {:error, "Invalid metainfo file: not a dictionary"}
+      {:error, error} -> {:error, error}
+    end
+  end
+
+  defp unwrap!(result) do
+    case result do
+      {:ok, value} -> value
+      {:error, %Bento.SyntaxError{} = error} -> raise error
       {:error, msg} -> raise Bento.MetainfoError, message: msg
     end
   end

--- a/mix.exs
+++ b/mix.exs
@@ -22,7 +22,7 @@ defmodule Bento.Mixfile do
   #
   # Type "mix help compile.app" for more information
   def application do
-    [extra_applications: [:logger]]
+    [extra_applications: [:logger, :crypto]]
   end
 
   defp description do
@@ -66,11 +66,12 @@ defmodule Bento.Mixfile do
           Bento.Fragment,
           Bento.OrderedDict
         ],
-        Metainfo: [
+        Torrents: [
           Bento.Metainfo,
           Bento.Metainfo.Torrent,
           Bento.Metainfo.SingleFile,
-          Bento.Metainfo.MultiFile
+          Bento.Metainfo.MultiFile,
+          Bento.Magnet
         ]
       ]
     ]

--- a/test/bento/magnet_test.exs
+++ b/test/bento/magnet_test.exs
@@ -254,7 +254,9 @@ defmodule Bento.MagnetTest do
             %Magnet{info_hash: @raw, keywords: ["two words"]},
             %Magnet{info_hash: @raw, select_only: [-1]},
             %Magnet{info_hash: @raw, select_only: [3..1//-1]},
-            %Magnet{info_hash: @raw, select_only: [0..6//2]}
+            %Magnet{info_hash: @raw, select_only: [0..6//2]},
+            %Magnet{info_hash: @raw, peers: ["nohost"]},
+            %Magnet{info_hash: @raw, peers: ["host:99999"]}
           ] do
         assert_raise MagnetError, fn -> Magnet.to_string(magnet) end
       end

--- a/test/bento/magnet_test.exs
+++ b/test/bento/magnet_test.exs
@@ -176,7 +176,21 @@ defmodule Bento.MagnetTest do
     end
 
     test "rejects malformed peer addresses" do
-      for peer <- ["nohost", "host:", ":6881", "host:0", "host:65536", "host:abc", "h:1%0A"] do
+      # Unbracketed IPv6 ("2001:db8::1:6881") is ambiguous with the port,
+      # so BEP-9 requires the [ipv6]:port form.
+      for peer <- [
+            "nohost",
+            "host:",
+            ":6881",
+            "host:0",
+            "host:65536",
+            "host:abc",
+            "h:1%0A",
+            "2001:db8::1:6881",
+            "%5B%5D:6881",
+            "%5B::1:6881",
+            "a%5Db:6881"
+          ] do
         assert {:error, %MagnetError{message: "Invalid peer address" <> _}} =
                  Magnet.parse("magnet:?xt=urn:btih:#{@hex}&x.pe=#{peer}")
       end
@@ -255,11 +269,31 @@ defmodule Bento.MagnetTest do
             %Magnet{info_hash: @raw, select_only: [-1]},
             %Magnet{info_hash: @raw, select_only: [3..1//-1]},
             %Magnet{info_hash: @raw, select_only: [0..6//2]},
+            %Magnet{info_hash: @raw, select_only: [Integer.pow(10, 20)]},
+            %Magnet{info_hash: @raw, select_only: [1..Integer.pow(10, 20)]},
+            %Magnet{info_hash: @raw, length: Integer.pow(10, 20)},
             %Magnet{info_hash: @raw, peers: ["nohost"]},
-            %Magnet{info_hash: @raw, peers: ["host:99999"]}
+            %Magnet{info_hash: @raw, peers: ["host:99999"]},
+            %Magnet{info_hash: @raw, peers: ["2001:db8::1:6881"]}
           ] do
         assert_raise MagnetError, fn -> Magnet.to_string(magnet) end
       end
+    end
+
+    test "renders values up to the parser's 20-digit integer limit" do
+      magnet = %Magnet{
+        info_hash: @raw,
+        length: Integer.pow(10, 20) - 1,
+        select_only: [Integer.pow(10, 20) - 1]
+      }
+
+      assert magnet |> Magnet.to_string() |> Magnet.parse!() == magnet
+    end
+
+    test "keeps error messages bounded for huge integers" do
+      magnet = %Magnet{info_hash: @raw, length: Integer.pow(10, 500)}
+      error = assert_raise MagnetError, fn -> Magnet.to_string(magnet) end
+      assert byte_size(error.message) < 200
     end
   end
 
@@ -400,6 +434,21 @@ defmodule Bento.MagnetTest do
       assert magnet.info_hash == nil
       assert magnet.info_hash_v2 == :crypto.hash(:sha256, Bento.encode!(info))
       assert magnet.length == 60
+    end
+
+    test "drops lengths past the rendering bound, keeping the struct renderable" do
+      data =
+        Bento.encode!(%{
+          "info" => %{
+            "length" => Integer.pow(10, 21),
+            "name" => "x",
+            "pieces" => <<0::160>>
+          }
+        })
+
+      magnet = Magnet.from_torrent!(data)
+      assert magnet.length == nil
+      assert magnet |> Magnet.to_string() |> Magnet.parse!() == magnet
     end
 
     test "rejects data that is not a metainfo dictionary" do

--- a/test/bento/magnet_test.exs
+++ b/test/bento/magnet_test.exs
@@ -189,11 +189,32 @@ defmodule Bento.MagnetTest do
             "2001:db8::1:6881",
             "%5B%5D:6881",
             "%5B::1:6881",
-            "a%5Db:6881"
+            "a%5Db:6881",
+            "bad+host:6881",
+            "%00:6881",
+            "-host:6881",
+            "host-:6881",
+            "host..name:6881",
+            "#{String.duplicate("a", 64)}:6881",
+            "%5Bzz::1%5D:6881",
+            "%5B1.2.3.4%5D:6881",
+            "%5B1:2:3%5D:6881"
           ] do
         assert {:error, %MagnetError{message: "Invalid peer address" <> _}} =
                  Magnet.parse("magnet:?xt=urn:btih:#{@hex}&x.pe=#{peer}")
       end
+    end
+
+    test "accepts hostname, IPv4, and bracketed IPv6 peer addresses" do
+      peers = [
+        "tracker-1.example.com:6881",
+        "192.0.2.7:6881",
+        "[2001:db8::1]:6881",
+        "[::ffff:192.0.2.7]:6881"
+      ]
+
+      query = Enum.map_join(peers, &("&x.pe=" <> URI.encode_www_form(&1)))
+      assert Magnet.parse!("magnet:?xt=urn:btih:#{@hex}" <> query).peers == peers
     end
 
     test "error messages stay bounded on oversized values" do
@@ -434,6 +455,32 @@ defmodule Bento.MagnetTest do
       assert magnet.info_hash == nil
       assert magnet.info_hash_v2 == :crypto.hash(:sha256, Bento.encode!(info))
       assert magnet.length == 60
+    end
+
+    test "returned strings do not retain the torrent binary" do
+      # Strings of 64+ bytes (such as passkey tracker URLs) decode as
+      # sub-binaries into the input; shorter ones land on the heap anyway.
+      url = "http://tracker.example.com/announce?passkey=" <> String.duplicate("a", 64)
+
+      data =
+        Bento.encode!(%{
+          "announce" => url,
+          "url-list" => [url <> "/webseed"],
+          "info" => %{
+            "length" => 1,
+            "name" => String.duplicate("n", 80),
+            "pieces" => :binary.copy(<<0::160>>, 100)
+          }
+        })
+
+      magnet = Magnet.from_torrent!(data)
+      strings = [magnet.display_name | magnet.trackers ++ magnet.web_seeds]
+      assert length(strings) == 3
+
+      for string <- strings do
+        # A sub-binary into the torrent would reference all of its bytes.
+        assert :binary.referenced_byte_size(string) == byte_size(string)
+      end
     end
 
     test "drops lengths past the rendering bound, keeping the struct renderable" do

--- a/test/bento/magnet_test.exs
+++ b/test/bento/magnet_test.exs
@@ -1,0 +1,429 @@
+defmodule Bento.MagnetTest do
+  use ExUnit.Case, async: true
+
+  doctest Bento.Magnet
+
+  alias Bento.{Magnet, MagnetError}
+
+  @hex "c12fe1c06bba254a9dc9f519b335aa7c1367a88a"
+  @raw Base.decode16!(@hex, case: :lower)
+  @base32 Base.encode32(@raw, padding: false)
+
+  # The BEP-52 example info-hash.
+  @v2_hex "caf1e1c30e81cb361b9ee167c4aa64228a7fa4fa9f6105232b28ad099f3a302e"
+  @v2_raw Base.decode16!(@v2_hex, case: :lower)
+
+  describe "parse/1" do
+    test "parses a minimal magnet URI" do
+      assert {:ok, magnet} = Magnet.parse("magnet:?xt=urn:btih:#{@hex}")
+      assert magnet.info_hash == @raw
+      assert magnet.info_hash_v2 == nil
+      assert magnet.display_name == nil
+      assert magnet.trackers == []
+    end
+
+    test "parses every supported parameter" do
+      uri =
+        "magnet:?xt=urn:btih:#{@hex}" <>
+          "&dn=Example+%26+File" <>
+          "&xl=123456789" <>
+          "&tr=udp%3A%2F%2Ftracker.example.com%3A80" <>
+          "&tr=http%3A%2F%2Fbackup.example.org%2Fannounce" <>
+          "&ws=http%3A%2F%2Fmirror.example%2Ffile" <>
+          "&as=http%3A%2F%2Fsource.example%2Ffile" <>
+          "&xs=http%3A%2F%2Fcache.example%2Ffile.torrent" <>
+          "&kt=red+hat&kt=linux" <>
+          "&so=0,2,4-6" <>
+          "&x.pe=192.0.2.7:6881&x.pe=%5B2001%3Adb8%3A%3A1%5D:6881"
+
+      assert {:ok, magnet} = Magnet.parse(uri)
+      assert magnet.info_hash == @raw
+      assert magnet.display_name == "Example & File"
+      assert magnet.length == 123_456_789
+
+      assert magnet.trackers == [
+               "udp://tracker.example.com:80",
+               "http://backup.example.org/announce"
+             ]
+
+      assert magnet.web_seeds == ["http://mirror.example/file"]
+      assert magnet.acceptable_sources == ["http://source.example/file"]
+      assert magnet.exact_sources == ["http://cache.example/file.torrent"]
+      assert magnet.keywords == ["red", "hat", "linux"]
+      assert magnet.select_only == [0, 2, 4..6]
+      assert magnet.peers == ["192.0.2.7:6881", "[2001:db8::1]:6881"]
+    end
+
+    test "accepts base32 info-hashes, uppercase and lowercase" do
+      assert Magnet.parse!("magnet:?xt=urn:btih:#{@base32}").info_hash == @raw
+      assert Magnet.parse!("magnet:?xt=urn:btih:#{String.downcase(@base32)}").info_hash == @raw
+    end
+
+    test "accepts uppercase hex info-hashes" do
+      assert Magnet.parse!("magnet:?xt=urn:btih:#{String.upcase(@hex)}").info_hash == @raw
+    end
+
+    test "accepts case-insensitive scheme and URN prefix" do
+      assert Magnet.parse!("MAGNET:?xt=URN:BTIH:#{@hex}").info_hash == @raw
+    end
+
+    test "parses v2 and hybrid exact topics" do
+      assert {:ok, v2} = Magnet.parse("magnet:?xt=urn:btmh:1220#{@v2_hex}")
+      assert v2.info_hash == nil
+      assert v2.info_hash_v2 == @v2_raw
+
+      assert {:ok, hybrid} =
+               Magnet.parse("magnet:?xt=urn:btih:#{@hex}&xt=urn:btmh:1220#{@v2_hex}")
+
+      assert hybrid.info_hash == @raw
+      assert hybrid.info_hash_v2 == @v2_raw
+    end
+
+    test "treats numbered parameters as their base parameter" do
+      assert {:ok, magnet} = Magnet.parse("magnet:?xt.1=urn:btih:#{@hex}&tr.1=a&tr.2=b")
+      assert magnet.info_hash == @raw
+      assert magnet.trackers == ["a", "b"]
+    end
+
+    test "ignores unknown parameters, empty values, and fragments" do
+      uri = "magnet:?xt=urn:btih:#{@hex}&dn=&future=yes&&x=1#fragment&tr=gone"
+      assert {:ok, magnet} = Magnet.parse(uri)
+      assert magnet.info_hash == @raw
+      assert magnet.display_name == nil
+      assert magnet.trackers == []
+    end
+
+    test "trims surrounding whitespace" do
+      assert {:ok, _} = Magnet.parse("  magnet:?xt=urn:btih:#{@hex}\n")
+    end
+
+    test "percent-decodes UTF-8 display names" do
+      assert Magnet.parse!("magnet:?xt=urn:btih:#{@hex}&dn=caf%C3%A9").display_name == "café"
+    end
+
+    test "rejects non-magnet URIs" do
+      for uri <- ["", "http://example.com/?xt=urn:btih:#{@hex}", "magnet:", "magnet"] do
+        assert {:error, %MagnetError{message: "Not a magnet URI:" <> _}} = Magnet.parse(uri)
+      end
+    end
+
+    test "rejects magnet URIs without an exact topic" do
+      assert {:error, %MagnetError{message: "Missing exact topic:" <> _}} =
+               Magnet.parse("magnet:?dn=name&tr=udp%3A%2F%2Fexample")
+    end
+
+    test "rejects unsupported exact topics" do
+      assert {:error, %MagnetError{message: "Unsupported exact topic" <> _}} =
+               Magnet.parse("magnet:?xt=urn:ed2k:31d6cfe0d16ae931b73c59d7e0c089c0")
+
+      assert {:error, %MagnetError{message: "Unsupported exact topic" <> _}} =
+               Magnet.parse("magnet:?xt=oops")
+    end
+
+    test "rejects malformed info-hashes" do
+      for xt <- [
+            # bad length
+            "urn:btih:abcdef",
+            # 40 chars, not hex
+            "urn:btih:" <> String.duplicate("zz", 20),
+            # 32 chars, not base32 (0 and 1 are not in the alphabet)
+            "urn:btih:" <> String.duplicate("01", 16),
+            # v2: valid hex, wrong multihash prefix
+            "urn:btmh:1120" <> @v2_hex,
+            # v2: truncated digest
+            "urn:btmh:1220" <> binary_part(@v2_hex, 0, 62),
+            # v2: not hex
+            "urn:btmh:zz20" <> @v2_hex
+          ] do
+        assert {:error, %MagnetError{}} = Magnet.parse("magnet:?xt=" <> xt)
+      end
+    end
+
+    test "rejects repeated single-valued parameters" do
+      base = "magnet:?xt=urn:btih:#{@hex}"
+
+      for uri <- [
+            base <> "&xt=urn:btih:#{String.upcase(@hex)}",
+            base <> "&xt=urn:btmh:1220#{@v2_hex}&xt=urn:btmh:1220#{@v2_hex}",
+            base <> "&dn=a&dn=b",
+            base <> "&xl=1&xl=2",
+            base <> "&so=1&so=2"
+          ] do
+        assert {:error, %MagnetError{message: "Duplicate parameter:" <> _}} = Magnet.parse(uri)
+      end
+    end
+
+    test "rejects malformed percent-encoding" do
+      for dn <- ["%zz", "%a", "100%", "%%41"] do
+        assert {:error, %MagnetError{message: "Malformed percent-encoding" <> _}} =
+                 Magnet.parse("magnet:?xt=urn:btih:#{@hex}&dn=#{dn}")
+      end
+    end
+
+    test "rejects malformed lengths" do
+      # "42%0A" decodes to "42\n": a `$`-anchored digit check would pass it.
+      for xl <- ["-1", "1.5", "abc", "1e3", "+1", "42%0A", String.duplicate("9", 21)] do
+        assert {:error, %MagnetError{message: "Invalid exact length" <> _}} =
+                 Magnet.parse("magnet:?xt=urn:btih:#{@hex}&xl=#{xl}")
+      end
+    end
+
+    test "rejects malformed select-only values" do
+      for so <- ["x", "1,", ",1", "1,,2", "3-1", "1-", "-1", "1-2-3", "1%0A"] do
+        assert {:error, %MagnetError{message: "Invalid select-only" <> _}} =
+                 Magnet.parse("magnet:?xt=urn:btih:#{@hex}&so=#{so}")
+      end
+    end
+
+    test "rejects malformed peer addresses" do
+      for peer <- ["nohost", "host:", ":6881", "host:0", "host:65536", "host:abc", "h:1%0A"] do
+        assert {:error, %MagnetError{message: "Invalid peer address" <> _}} =
+                 Magnet.parse("magnet:?xt=urn:btih:#{@hex}&x.pe=#{peer}")
+      end
+    end
+
+    test "error messages stay bounded on oversized values" do
+      huge = String.duplicate("a", 100_000)
+      assert {:error, error} = Magnet.parse("magnet:?xt=urn:btih:#{huge}")
+      assert byte_size(error.message) < 200
+    end
+
+    test "parse!/1 raises on malformed input" do
+      assert_raise MagnetError, fn -> Magnet.parse!("magnet:?dn=x") end
+    end
+  end
+
+  describe "to_string/1" do
+    test "round-trips a fully populated struct" do
+      magnet = %Magnet{
+        info_hash: @raw,
+        info_hash_v2: @v2_raw,
+        display_name: "Example & File",
+        length: 42,
+        trackers: ["udp://tracker.example.com:80"],
+        web_seeds: ["http://mirror.example/file"],
+        acceptable_sources: ["http://source.example/file"],
+        exact_sources: ["http://cache.example/file.torrent"],
+        keywords: ["red", "hat"],
+        select_only: [0, 2, 4..6],
+        peers: ["192.0.2.7:6881", "[2001:db8::1]:6881"]
+      }
+
+      assert magnet |> Magnet.to_string() |> Magnet.parse!() == magnet
+    end
+
+    test "emits parameters in conventional order" do
+      magnet = %Magnet{info_hash: @raw, display_name: "x", length: 1, trackers: ["t"]}
+      assert Magnet.to_string(magnet) == "magnet:?xt=urn:btih:#{@hex}&dn=x&xl=1&tr=t"
+    end
+
+    test "emits both topics for hybrid torrents" do
+      assert Magnet.to_string(%Magnet{info_hash: @raw, info_hash_v2: @v2_raw}) ==
+               "magnet:?xt=urn:btih:#{@hex}&xt=urn:btmh:1220#{@v2_hex}"
+    end
+
+    test "leaves colons and brackets raw in peer addresses" do
+      magnet = %Magnet{info_hash: @raw, peers: ["[2001:db8::1]:6881"]}
+      assert Magnet.to_string(magnet) =~ "&x.pe=[2001:db8::1]:6881"
+    end
+
+    test "skips nil and empty values" do
+      magnet = %Magnet{info_hash: @raw, display_name: "", trackers: ["", "t"]}
+      assert Magnet.to_string(magnet) == "magnet:?xt=urn:btih:#{@hex}&tr=t"
+    end
+
+    test "implements String.Chars" do
+      assert "#{%Magnet{info_hash: @raw}}" == "magnet:?xt=urn:btih:#{@hex}"
+    end
+
+    test "raises without an info-hash" do
+      assert_raise MagnetError, "Cannot render a magnet URI without an info-hash", fn ->
+        Magnet.to_string(%Magnet{display_name: "x"})
+      end
+    end
+
+    test "raises on invalid field values" do
+      for magnet <- [
+            %Magnet{info_hash: "too short"},
+            %Magnet{info_hash: @raw <> "x"},
+            %Magnet{info_hash_v2: @raw},
+            %Magnet{info_hash: @raw, length: -1},
+            %Magnet{info_hash: @raw, display_name: 42},
+            %Magnet{info_hash: @raw, trackers: [:not_a_string]},
+            %Magnet{info_hash: @raw, trackers: "not a list"},
+            %Magnet{info_hash: @raw, keywords: ["two words"]},
+            %Magnet{info_hash: @raw, select_only: [-1]},
+            %Magnet{info_hash: @raw, select_only: [3..1//-1]},
+            %Magnet{info_hash: @raw, select_only: [0..6//2]}
+          ] do
+        assert_raise MagnetError, fn -> Magnet.to_string(magnet) end
+      end
+    end
+  end
+
+  describe "from_torrent/1" do
+    @single_file File.read!(Path.expand("./test/_data/ubuntu-14.04.4-desktop-amd64.iso.torrent"))
+    @multi_file File.read!(Path.expand("./test/_data/huck_finn_librivox_archive.torrent"))
+
+    test "builds a magnet link from a single-file torrent" do
+      assert {:ok, magnet} = Magnet.from_torrent(@single_file)
+
+      # Independently computed: the SHA-1 of the raw info dictionary bytes,
+      # sliced straight out of the file (see "matches a raw byte slice").
+      assert Base.encode16(magnet.info_hash, case: :lower) ==
+               "33395da120c9a4758e896ded4dec5f2495c9973f"
+
+      assert magnet.info_hash_v2 == nil
+      assert magnet.display_name == "ubuntu-14.04.4-desktop-amd64.iso"
+      assert magnet.length == 1_069_547_520
+
+      assert magnet.trackers == [
+               "http://torrent.ubuntu.com:6969/announce",
+               "http://ipv6.torrent.ubuntu.com:6969/announce"
+             ]
+    end
+
+    test "builds a magnet link from a multi-file torrent" do
+      assert {:ok, magnet} = Magnet.from_torrent(@multi_file)
+
+      assert Base.encode16(magnet.info_hash, case: :lower) ==
+               "a40d3a5b3e9f32a1f5540875e2188f6b7709fc58"
+
+      assert magnet.display_name == "huck_finn_librivox"
+
+      # The sum of all 321 file lengths.
+      torrent = Bento.torrent!(@multi_file)
+      assert magnet.length == torrent.info.files |> Enum.map(& &1.length) |> Enum.sum()
+
+      # BEP-19 url-list entries become web seeds.
+      assert "https://archive.org/download/" in magnet.web_seeds
+    end
+
+    test "info-hash matches a raw byte slice of the torrent file" do
+      for bytes <- [@single_file, @multi_file] do
+        # An independent oracle: the info value's bytes are located by
+        # parsing one value off the input right after the "info" key.
+        {pos, 6} = :binary.match(bytes, "4:info")
+        start = pos + 6
+        value_and_rest = binary_part(bytes, start, byte_size(bytes) - start)
+        {_value, rest} = Bento.decode_prefix!(value_and_rest)
+        info_bytes = binary_part(value_and_rest, 0, byte_size(value_and_rest) - byte_size(rest))
+
+        assert Magnet.from_torrent!(bytes).info_hash == :crypto.hash(:sha, info_bytes)
+      end
+    end
+
+    test "hashes the original bytes of non-canonical files" do
+      # Unsorted info keys: hashing a re-sorted re-encoding would produce a
+      # different (wrong) hash than clients hashing the file as-is.
+      info = "d6:pieces20:#{<<0::160>>}4:name7:example6:lengthi42e12:piece lengthi16384ee"
+      torrent = "d8:announce7:udp://t4:info#{info}e"
+
+      assert Magnet.from_torrent!(torrent).info_hash == :crypto.hash(:sha, info)
+    end
+
+    test "prefers the nonstandard name.utf-8 key for the display name" do
+      data =
+        Bento.encode!(%{
+          "info" => %{
+            "length" => 1,
+            "name" => <<"caf", 0xE9>>,
+            "name.utf-8" => "café",
+            "pieces" => <<0::160>>
+          }
+        })
+
+      assert Magnet.from_torrent!(data).display_name == "café"
+    end
+
+    test "uses announce when announce-list is absent or empty" do
+      base = %{"info" => %{"length" => 1, "name" => "x", "pieces" => <<0::160>>}}
+
+      data = Bento.encode!(Map.put(base, "announce", "udp://a"))
+      assert Magnet.from_torrent!(data).trackers == ["udp://a"]
+
+      data = Bento.encode!(base |> Map.put("announce", "udp://a") |> Map.put("announce-list", []))
+      assert Magnet.from_torrent!(data).trackers == ["udp://a"]
+
+      assert Magnet.from_torrent!(Bento.encode!(base)).trackers == []
+    end
+
+    test "flattens and deduplicates announce-list tiers" do
+      data =
+        Bento.encode!(%{
+          "announce" => "udp://a",
+          "announce-list" => [["udp://a", "udp://b"], ["udp://a"], ["udp://c"]],
+          "info" => %{"length" => 1, "name" => "x", "pieces" => <<0::160>>}
+        })
+
+      assert Magnet.from_torrent!(data).trackers == ["udp://a", "udp://b", "udp://c"]
+    end
+
+    test "builds a hybrid magnet link from a BEP-52 hybrid torrent" do
+      data =
+        Bento.encode!(%{
+          "info" => %{
+            "file tree" => %{"x" => %{"" => %{"length" => 42, "pieces root" => <<0::256>>}}},
+            "length" => 42,
+            "meta version" => 2,
+            "name" => "x",
+            "piece length" => 16_384,
+            "pieces" => <<0::160>>
+          }
+        })
+
+      magnet = Magnet.from_torrent!(data)
+      assert byte_size(magnet.info_hash) == 20
+      assert byte_size(magnet.info_hash_v2) == 32
+      assert magnet.length == 42
+    end
+
+    test "builds a v2-only magnet link with the file tree's total length" do
+      info = %{
+        "file tree" => %{
+          "dir" => %{
+            "a.txt" => %{"" => %{"length" => 10, "pieces root" => <<0::256>>}},
+            "b.txt" => %{"" => %{"length" => 20, "pieces root" => <<1::256>>}}
+          },
+          "c.txt" => %{"" => %{"length" => 30, "pieces root" => <<2::256>>}}
+        },
+        "meta version" => 2,
+        "name" => "x",
+        "piece length" => 16_384
+      }
+
+      data = Bento.encode!(%{"info" => info})
+      magnet = Magnet.from_torrent!(data)
+
+      assert magnet.info_hash == nil
+      assert magnet.info_hash_v2 == :crypto.hash(:sha256, Bento.encode!(info))
+      assert magnet.length == 60
+    end
+
+    test "rejects data that is not a metainfo dictionary" do
+      assert {:error, %Bento.SyntaxError{}} = Magnet.from_torrent("not bencoding")
+      assert {:error, %MagnetError{message: msg}} = Magnet.from_torrent("i42e")
+      assert msg == "Invalid metainfo file: not a dictionary"
+
+      assert {:error, %MagnetError{}} = Magnet.from_torrent("de")
+      assert {:error, %MagnetError{}} = Magnet.from_torrent("d4:infoi42ee")
+
+      # An info dictionary that is neither v1 nor v2.
+      assert {:error, %MagnetError{}} =
+               Magnet.from_torrent(Bento.encode!(%{"info" => %{"name" => "x"}}))
+    end
+
+    test "rejects duplicate info dictionaries" do
+      info = "d6:lengthi1e4:name1:x6:pieces20:#{<<0::160>>}e"
+      data = "d4:info#{info}4:info#{info}e"
+
+      assert {:error, %MagnetError{message: msg}} = Magnet.from_torrent(data)
+      assert msg == "Invalid metainfo file: duplicate info dictionary"
+    end
+
+    test "from_torrent!/1 raises on error" do
+      assert_raise MagnetError, fn -> Magnet.from_torrent!("de") end
+      assert_raise Bento.SyntaxError, fn -> Magnet.from_torrent!("oops") end
+    end
+  end
+end

--- a/test/bento/magnet_test.exs
+++ b/test/bento/magnet_test.exs
@@ -416,6 +416,25 @@ defmodule Bento.MagnetTest do
       assert Magnet.from_torrent!(data).trackers == ["udp://a", "udp://b", "udp://c"]
     end
 
+    test "excludes BEP-47 padding files from the length" do
+      data =
+        Bento.encode!(%{
+          "info" => %{
+            "files" => [
+              %{"length" => 100, "path" => ["a.txt"]},
+              %{"attr" => "p", "length" => 28, "path" => [".pad", "28"]},
+              # Other attr flags (executable) still count.
+              %{"attr" => "x", "length" => 50, "path" => ["b"]}
+            ],
+            "name" => "x",
+            "piece length" => 128,
+            "pieces" => <<0::320>>
+          }
+        })
+
+      assert Magnet.from_torrent!(data).length == 150
+    end
+
     test "builds a hybrid magnet link from a BEP-52 hybrid torrent" do
       data =
         Bento.encode!(%{

--- a/test/bento/metainfo_test.exs
+++ b/test/bento/metainfo_test.exs
@@ -1,6 +1,9 @@
 defmodule Bento.MetainfoTest do
   use ExUnit.Case, async: true
 
+  doctest Bento.Metainfo
+
+  alias Bento.Metainfo
   alias Bento.MetainfoError
   alias Bento.Metainfo.Torrent
 
@@ -78,6 +81,72 @@ defmodule Bento.MetainfoTest do
     file = List.first(torrent.info.files)
     assert file.path == ["dir", <<"caf", 0xE9, ".txt">>]
     assert file."path.utf-8" == ["dir", "café.txt"]
+  end
+
+  describe "info_hash/1" do
+    test "computes the v1 info-hash of real torrent files" do
+      assert {:ok, hash} = Metainfo.info_hash(@single_file)
+      assert Base.encode16(hash, case: :lower) == "33395da120c9a4758e896ded4dec5f2495c9973f"
+
+      assert Metainfo.info_hash!(@multi_file) |> Base.encode16(case: :lower) ==
+               "a40d3a5b3e9f32a1f5540875e2188f6b7709fc58"
+    end
+
+    test "hashes the exact original bytes, even for non-canonical files" do
+      # Unsorted keys inside the info dictionary: the hash must cover the
+      # bytes as they appear in the file, not a canonical re-encoding.
+      info = "d6:pieces20:#{<<0::160>>}4:name1:x6:lengthi1ee"
+      data = "d4:info#{info}e"
+
+      assert Metainfo.info_hash!(data) == :crypto.hash(:sha, info)
+    end
+
+    test "returns errors for invalid or v2-only metainfo" do
+      assert {:error, %Bento.SyntaxError{}} = Metainfo.info_hash("garbage")
+      assert {:error, "Invalid metainfo file: not a dictionary"} = Metainfo.info_hash("le")
+      assert {:error, "Invalid metainfo file: missing info dictionary"} = Metainfo.info_hash("de")
+
+      assert {:error, "Invalid metainfo file: info is not a dictionary"} =
+               Metainfo.info_hash("d4:infoi42ee")
+
+      v2_only = Bento.encode!(%{"info" => %{"meta version" => 2, "name" => "x"}})
+      assert {:error, "Not a v1 torrent:" <> _} = Metainfo.info_hash(v2_only)
+    end
+
+    test "rejects duplicate info dictionaries" do
+      info = "d6:lengthi1e4:name1:x6:pieces20:#{<<0::160>>}e"
+      data = "d4:info#{info}4:info#{info}e"
+
+      assert {:error, "Invalid metainfo file: duplicate info dictionary"} =
+               Metainfo.info_hash(data)
+    end
+
+    test "info_hash!/1 raises on error" do
+      assert_raise MetainfoError, fn -> Metainfo.info_hash!("de") end
+      assert_raise Bento.SyntaxError, fn -> Metainfo.info_hash!("garbage") end
+    end
+  end
+
+  describe "info_hash_v2/1" do
+    test "computes the v2 info-hash of a BEP-52 torrent" do
+      info = %{
+        "file tree" => %{"x" => %{"" => %{"length" => 1, "pieces root" => <<0::256>>}}},
+        "meta version" => 2,
+        "name" => "x",
+        "piece length" => 16_384
+      }
+
+      data = Bento.encode!(%{"info" => info})
+
+      assert {:ok, hash} = Metainfo.info_hash_v2(data)
+      assert hash == :crypto.hash(:sha256, Bento.encode!(info))
+      assert Metainfo.info_hash_v2!(data) == hash
+    end
+
+    test "returns an error for v1 torrents" do
+      assert {:error, "Not a v2 torrent:" <> _} = Metainfo.info_hash_v2(@single_file)
+      assert_raise MetainfoError, fn -> Metainfo.info_hash_v2!(@single_file) end
+    end
   end
 
   test "unknown metainfo keys are allowed and ignored" do

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -86,6 +86,76 @@ if Code.ensure_loaded?(ExUnitProperties) do
       end
     end
 
+    property "magnet links round-trip through to_string |> parse" do
+      check all(magnet <- magnet()) do
+        assert magnet |> Bento.Magnet.to_string() |> Bento.Magnet.parse!() == magnet
+      end
+    end
+
+    property "parsing mutated magnet links returns an error or a value, never crashes" do
+      check all(
+              magnet <- magnet(),
+              index <- non_negative_integer(),
+              replacement <- integer(0..255)
+            ) do
+        bytes = Bento.Magnet.to_string(magnet)
+        index = rem(index, byte_size(bytes))
+
+        <<prefix::binary-size(index), _byte, suffix::binary>> = bytes
+        mutated = <<prefix::binary, replacement, suffix::binary>>
+
+        case Bento.Magnet.parse(mutated) do
+          {:ok, _} ->
+            :ok
+
+          {:error, %Bento.MagnetError{} = error} ->
+            # Messages must stay bounded no matter the input.
+            assert byte_size(Exception.message(error)) < 200
+        end
+      end
+    end
+
+    defp magnet do
+      gen all(
+            info_hash <- binary(length: 20),
+            info_hash_v2 <- one_of([constant(nil), binary(length: 32)]),
+            display_name <- one_of([constant(nil), binary(min_length: 1)]),
+            length <- one_of([constant(nil), non_negative_integer()]),
+            trackers <- list_of(binary(min_length: 1)),
+            web_seeds <- list_of(binary(min_length: 1)),
+            keywords <- list_of(string(:alphanumeric, min_length: 1)),
+            select_only <- list_of(select_item()),
+            peers <- list_of(peer())
+          ) do
+        %Bento.Magnet{
+          info_hash: info_hash,
+          info_hash_v2: info_hash_v2,
+          display_name: display_name,
+          length: length,
+          trackers: trackers,
+          web_seeds: web_seeds,
+          keywords: keywords,
+          select_only: select_only,
+          peers: peers
+        }
+      end
+    end
+
+    defp select_item do
+      one_of([
+        non_negative_integer(),
+        gen all(first <- non_negative_integer(), span <- non_negative_integer()) do
+          first..(first + span)
+        end
+      ])
+    end
+
+    defp peer do
+      gen all(host <- string(:alphanumeric, min_length: 1), port <- integer(1..65_535)) do
+        "#{host}:#{port}"
+      end
+    end
+
     defp bencodable(key_generator_or_generators) do
       key_generators = List.wrap(key_generator_or_generators)
       simple = one_of([integer(), binary()])

--- a/test/property_test.exs
+++ b/test/property_test.exs
@@ -151,7 +151,11 @@ if Code.ensure_loaded?(ExUnitProperties) do
     end
 
     defp peer do
-      gen all(host <- string(:alphanumeric, min_length: 1), port <- integer(1..65_535)) do
+      # Hosts must satisfy the RFC 1123 label grammar (up to 63 chars).
+      gen all(
+            host <- string(:alphanumeric, min_length: 1, max_length: 63),
+            port <- integer(1..65_535)
+          ) do
         "#{host}:#{port}"
       end
     end


### PR DESCRIPTION
Implements a complete magnet URI codec for BitTorrent, supporting BEP-9 (magnet links), BEP-52 (v2 info-hashes), and BEP-53 (select-only extension).

## Summary

This PR adds `Bento.Magnet`, a new module that provides strict parsing and rendering of magnet URIs. It includes support for both v1 (SHA-1) and v2 (SHA-256) info-hashes, and can generate magnet links directly from torrent metainfo files.

## Key Changes

- **New `Bento.Magnet` module**: Provides `parse/1`, `parse!/1`, `to_string/1`, and `from_torrent/1` functions for magnet URI handling
  - Strict parsing that rejects malformed input with descriptive errors
  - Supports v1 info-hashes in hex (40 chars) or base32 (32 chars)
  - Supports v2 info-hashes as sha2-256 multihashes (BEP-52)
  - Handles all standard parameters: trackers, web seeds, display name, length, keywords, peer addresses, and select-only indices (BEP-53)
  - Implements `String.Chars` protocol for string interpolation

- **New `Bento.MagnetError` exception**: Raised for parsing/rendering errors with bounded, descriptive messages

- **Extended `Bento.Metainfo`**: Added `info_hash/1`, `info_hash!/1`, `info_hash_v2/1`, and `info_hash_v2!/1` functions to compute v1 and v2 info-hashes from raw torrent bytes, preserving exact byte representation for non-canonical files

- **New `Bento.magnet/1` and `Bento.magnet!/1`**: High-level API functions in the main module

- **Property-based tests**: Added comprehensive property tests for magnet link round-tripping and mutation resilience

- **Documentation**: Added `AGENTS.md` with setup instructions for development environments

## Notable Implementation Details

- Info-hashes are stored as raw binaries (wire protocol format) and normalized to lowercase hex when rendering
- Parsing uses `OrderedDict` to preserve dictionary key order, ensuring correct hash computation for non-canonical files
- Percent-encoding is validated strictly; malformed escapes are rejected rather than passed through
- Integer parameters are bounded to 20 digits to prevent adversarial big-integer conversions
- Error messages are bounded in size to prevent DoS via oversized input
- The `from_torrent/1` function hashes the exact bytes of the info dictionary as they appear in the file, matching other BitTorrent clients even for non-canonical encodings

https://claude.ai/code/session_015g9sCKR2jaanc7yG97KiSK